### PR TITLE
Link to pass obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,10 +395,11 @@ Trig new route.
 
 **Props:**
 
-- **to** `string` Path ex: "/foo". Can be absolute `/path/foo` or
-  relative `path/foo`
-- **className** `string` _(optional)_ Class name added to component root DOM
-  element
+- **to** `string | TOpenRouteParams` Path ex: `/foo` or `{name: "FooPage" params: { id: bar }}`. 
+  "to" props accepts same params than setLocation.
+- **children** `ReactNode` children link DOM element 
+- **onClick** `()=> void` _(optional)_ execute callback on the click event
+- **className** `string` _(optional)_ Class name added to component root DOM element
 
 ### <a name="Stack"></a>Stack
 
@@ -712,7 +713,6 @@ Return languages list
 ```jsx
 const langages = LangService.languages;
 ```
-
 
 #### currentLang `TLanguage`
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -65,7 +65,9 @@ export default function App() {
             <Link to={"/about"}>About</Link>
           </li>
           <li>
-            <Link to={"/blog/article-1"}>Blog id:article-1</Link>
+            <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>
+              Blog id:article-1
+            </Link>
           </li>
         </ul>
       </nav>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, useMemo } from "react";
 import { prepareSetLocationUrl, useLocation } from "..";
-import { joinPaths } from "../api/helpers";
+import { joinPaths, TOpenRouteParams } from "../api/helpers";
 
 interface IProps {
-  to: string;
+  to: string | TOpenRouteParams;
   onClick?: () => void;
   className?: string;
   children: ReactNode;

--- a/test/Link.test.tsx
+++ b/test/Link.test.tsx
@@ -9,6 +9,7 @@ const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 const routesList: TRoute[] = [
   { path: "/", component: null, name: "HomePage" },
   { path: "/foo", component: null, name: "FooPage" },
+  { path: "/bar/:id", component: null, name: "BarPage" },
 ];
 
 afterEach(() => {
@@ -64,11 +65,19 @@ describe("Link", () => {
     fireEvent.click(container.firstChild);
     expect(mockClickHandler.mock.calls.length).toBe(3);
   });
-  
+
   it("should return the right href URL", () => {
     const { container } = render(<App base={"/"} to={{ name: "FooPage" }} />);
     fireEvent.click(container.firstChild);
     expect(ROUTERS.history.location.pathname).toBe("/foo");
+  });
+
+  it("should return the right href URL with param", () => {
+    const { container } = render(
+      <App base={"/"} to={{ name: "BarPage", params: { id: "test" } }} />
+    );
+    fireEvent.click(container.firstChild);
+    expect(ROUTERS.history.location.pathname).toBe("/bar/test");
   });
 
   it("should push in history on click", () => {
@@ -77,5 +86,4 @@ describe("Link", () => {
     expect(ROUTERS.history.location.pathname).toBe("/bar");
     expect(ROUTERS.history.action).toBe("PUSH");
   });
-
 });

--- a/test/Link.test.tsx
+++ b/test/Link.test.tsx
@@ -3,11 +3,12 @@ import { Link, Router, TRoute } from "../src";
 import { render, fireEvent } from "@testing-library/react";
 import { ROUTERS } from "../src/api/routers";
 import { LangService } from "../src";
+import { TOpenRouteParams } from "../src/api/helpers";
 
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 const routesList: TRoute[] = [
-  { path: "/", component: null },
-  { path: "/foo", component: null },
+  { path: "/", component: null, name: "HomePage" },
+  { path: "/foo", component: null, name: "FooPage" },
 ];
 
 afterEach(() => {
@@ -15,7 +16,7 @@ afterEach(() => {
 });
 
 const mockClickHandler = jest.fn();
-const App = ({ base = "/", to = "/foo" }) => {
+const App = ({ base = "/", to }: { base: string; to: string | TOpenRouteParams }) => {
   return (
     <Router base={base} routes={routesList}>
       <Link to={to} className={"containerLink"} onClick={mockClickHandler}>
@@ -63,11 +64,18 @@ describe("Link", () => {
     fireEvent.click(container.firstChild);
     expect(mockClickHandler.mock.calls.length).toBe(3);
   });
+  
+  it("should return the right href URL", () => {
+    const { container } = render(<App base={"/"} to={{ name: "FooPage" }} />);
+    fireEvent.click(container.firstChild);
+    expect(ROUTERS.history.location.pathname).toBe("/foo");
+  });
 
   it("should push in history on click", () => {
-    const { container } = render(<App to={"/bar"} />);
+    const { container } = render(<App base={"/"} to={"/bar"} />);
     fireEvent.click(container.firstChild);
     expect(ROUTERS.history.location.pathname).toBe("/bar");
     expect(ROUTERS.history.action).toBe("PUSH");
   });
+
 });


### PR DESCRIPTION
fix #40 

Can now use link on the same way than  `useLocation` seter:

```jsx
<Link to={{ name:"Foo", params: {id: "bar"} }}> 
```