### PR TITLE
Fix not found route

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -69,6 +69,9 @@ export default function App() {
               Blog id:article-1
             </Link>
           </li>
+          <li>
+            <Link to={"/not/found/"}>Not found route</Link>
+          </li>
         </ul>
       </nav>
       <Stack className={"App_stack"} />

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -184,18 +184,26 @@ export class CreateRouter {
     // get matching route depending of current URL
     const matchingRoute: TRoute = this.getRouteFromUrl({ pUrl: url });
 
-    if (!matchingRoute) {
-      debug(this.id, "updateRoute: NO MATCHING ROUTE. RETURN.");
+    // get not found route
+    const notFoundRoute: TRoute = this.preMiddlewareRoutes.find(
+      (el) => el.path === "/:rest" || el.component?.displayName === "NotFoundPage"
+    );
+
+    if (!matchingRoute && !notFoundRoute) {
+      debug(this.id, "updateRoute: NO MATCHING ROUTE & NO NOTFOUND ROUTE. RETURN.");
       return;
     }
 
-    if (this.currentRoute?.matchUrl === matchingRoute?.matchUrl) {
+    if (
+      this.currentRoute?.matchUrl != null &&
+      this.currentRoute?.matchUrl === matchingRoute?.matchUrl
+    ) {
       debug(this.id, "updateRoute > THIS IS THE SAME URL, RETURN.");
       return;
     }
 
     this.previousRoute = this.currentRoute;
-    this.currentRoute = matchingRoute;
+    this.currentRoute = matchingRoute || notFoundRoute;
 
     this.events.emit(ERouterEvent.PREVIOUS_ROUTE_CHANGE, this.previousRoute);
     this.events.emit(ERouterEvent.CURRENT_ROUTE_CHANGE, this.currentRoute);


### PR DESCRIPTION
fix #32 

route with path: `/:rest` will now be render if current route doesn't match with any route of the list ; no matter the declaration level.

ex: 
if route list is : 

```ts
const routesList = [
  {
    path: "/",
    component: HomePage,
  },
  {
    path: "/:rest",
    component: forwardRef((props, r) => <div className="NotFoundPage">Not Found</div>),
  },
];
```

path `/not/found/page/exist/in/route/list` will return the component matching with path "/:rest"

cc @yoanngueny 