### PR TITLE
WIP accept translated path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Middlewares:
 Services:
 
 - [`LangService`](#LangService) Manage `:lang` params
+- [`Translate Path`](#TranslatePath)
 
 ## <a name="Installation"></a>Installation
 
@@ -395,9 +396,9 @@ Trig new route.
 
 **Props:**
 
-- **to** `string | TOpenRouteParams` Path ex: `/foo` or `{name: "FooPage" params: { id: bar }}`. 
+- **to** `string | TOpenRouteParams` Path ex: `/foo` or `{name: "FooPage" params: { id: bar }}`.
   "to" props accepts same params than setLocation.
-- **children** `ReactNode` children link DOM element 
+- **children** `ReactNode` children link DOM element
 - **onClick** `()=> void` _(optional)_ execute callback on the click event
 - **className** `string` _(optional)_ Class name added to component root DOM element
 
@@ -763,6 +764,17 @@ only.
 
 ```jsx
 LangService.redirect();
+```
+
+### <a name="TranslatePath"></a>Translate Path
+
+Paths can be translated by lang in route path property:
+
+```js
+  {
+    path: { en: "/foo", fr: "/foo-fr", de: "/foo-de" },
+    component: FooPage,
+  }
 ```
 
 ## Credits

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -56,10 +56,10 @@ export default function App() {
       <nav>
         <ul>
           <li>
-            <Link to={"/"}>Home</Link>
+            <Link to={{ name:"HomePage" }}>Home</Link>
           </li>
           <li>
-            <Link to={"/about"}>About</Link>
+            <Link to={{ name:"AboutPage" }}>About</Link>
           </li>
           <li>
             <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { Link, useRouteCounter, Stack, useHistory } from "../src";
 import { LangService } from "../src";
-import { getLangPathByPath } from "../src/lang/langHelpers";
 
 const componentName = "App";
 const debug = require("debug")(`router:${componentName}`);
@@ -60,7 +59,7 @@ export default function App() {
             <Link to={"/"}>Home</Link>
           </li>
           <li>
-            <Link to={getLangPathByPath({ path: "/about" })}>About</Link>
+            <Link to={"/about"}>About</Link>
           </li>
           <li>
             <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { Link, useRouteCounter, Stack, useHistory } from "../src";
 import { LangService } from "../src";
+import { getLangPathByPath } from "../src/lang/langHelpers";
 
 const componentName = "App";
 const debug = require("debug")(`router:${componentName}`);
@@ -59,7 +60,7 @@ export default function App() {
             <Link to={"/"}>Home</Link>
           </li>
           <li>
-            <Link to={"/about"}>About</Link>
+            <Link to={getLangPathByPath("/about")}>About</Link>
           </li>
           <li>
             <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -60,7 +60,7 @@ export default function App() {
             <Link to={"/"}>Home</Link>
           </li>
           <li>
-            <Link to={getLangPathByPath("/about")}>About</Link>
+            <Link to={getLangPathByPath({ path: "/about" })}>About</Link>
           </li>
           <li>
             <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -61,14 +61,14 @@ export default function App() {
           <li>
             <Link to={{ name:"AboutPage" }}>About</Link>
           </li>
-          <li>
-            <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>
-              Blog id:article-1
-            </Link>
-          </li>
-          <li>
-            <Link to={"/not/found/"}>Not found route</Link>
-          </li>
+          {/*<li>*/}
+          {/*  <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>*/}
+          {/*    Blog id:article-1*/}
+          {/*  </Link>*/}
+          {/*</li>*/}
+          {/*<li>*/}
+          {/*  <Link to={"/not/found/"}>Not found route</Link>*/}
+          {/*</li>*/}
         </ul>
       </nav>
       <Stack className={"App_stack"} />

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Link, useRouteCounter, Stack, useHistory } from "../src";
+import { Link, Stack } from "../src";
 import { LangService } from "../src";
 
 const componentName = "App";
@@ -9,16 +9,6 @@ const debug = require("debug")(`router:${componentName}`);
  * @name App
  */
 export default function App() {
-  const history = useHistory();
-  useEffect(() => {
-    debug("history", history);
-  }, [history]);
-
-  const count = useRouteCounter();
-  useEffect(() => {
-    debug("count", count);
-  }, [count]);
-
   useEffect(() => {
     LangService.redirect();
   }, []);
@@ -56,19 +46,19 @@ export default function App() {
       <nav>
         <ul>
           <li>
-            <Link to={{ name:"HomePage" }}>Home</Link>
+            <Link to={{ name: "HomePage" }}>Home</Link>
           </li>
           <li>
-            <Link to={{ name:"AboutPage" }}>About</Link>
+            <Link to={{ name: "AboutPage" }}>About</Link>
           </li>
-          {/*<li>*/}
-          {/*  <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>*/}
-          {/*    Blog id:article-1*/}
-          {/*  </Link>*/}
-          {/*</li>*/}
-          {/*<li>*/}
-          {/*  <Link to={"/not/found/"}>Not found route</Link>*/}
-          {/*</li>*/}
+          <li>
+            <Link to={{ name: "ArticlePage", params: { id: "article-1" } }}>
+              Blog id:article-1
+            </Link>
+          </li>
+          <li>
+            <Link to={"/not/found/"}>Not found route</Link>
+          </li>
         </ul>
       </nav>
       <Stack className={"App_stack"} />

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -34,7 +34,7 @@ export const routesList: TRoute[] = [
     component: AboutPage,
     children: [
       {
-        path: "/foo",
+        path: { en: "/foo", fr: "/foo-fr" },
         component: FooPage,
       },
       {

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -51,7 +51,6 @@ export const routesList: TRoute[] = [
 
 const baseUrl = "/master";
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
-
 LangService.init(locales, true, baseUrl);
 
 /**

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -19,18 +19,18 @@ const debug = require("debug")(`router:index`);
  */
 export const routesList: TRoute[] = [
   {
-    path: "/",
+    path: { en: "/", fr: "/" },
     component: HomePage,
   },
   {
-    path: "/blog/:id",
+    path: { en: "/blog/:id", fr: "/blog-fr/:id" },
     component: ArticlePage,
     props: {
       color: "red",
     },
   },
   {
-    path: "/about",
+    path: { en: "/about", fr: "/a-propos" },
     component: AboutPage,
     children: [
       {

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -49,9 +49,9 @@ export const routesList: TRoute[] = [
   },
 ];
 
-const baseUrl = "/master";
+const baseUrl = "/custom-base";
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
-LangService.init(locales, true, baseUrl);
+LangService.init(locales, false, baseUrl);
 
 /**
  * Init Application

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -19,22 +19,26 @@ const debug = require("debug")(`router:index`);
  */
 export const routesList: TRoute[] = [
   {
+    // path: "/",
     path: { en: "/", fr: "/", de: "/" },
     component: HomePage,
   },
   {
-    path: { en: "/blog/:id", fr: "/blog-fr/:id", de: "/blog-de/:id" },
+    path: "/blog/:id",
+    //path: { en: "/blog/:id", fr: "/blog-fr/:id", de: "/blog-de/:id" },
     component: ArticlePage,
     props: {
       color: "red",
     },
   },
   {
-    path: { en: "/about", fr: "/a-propos", de: "/uber" },
+    path: "/about",
+    //path: { en: "/about", fr: "/a-propos", de: "/uber" },
     component: AboutPage,
     children: [
       {
-        path: { en: "/foo", fr: "/foo-fr", de: "/foo-de" },
+        path: "/foo",
+        // path: { en: "/foo", fr: "/foo-fr", de: "/foo-de" },
         component: FooPage,
       },
       {

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -19,22 +19,22 @@ const debug = require("debug")(`router:index`);
  */
 export const routesList: TRoute[] = [
   {
-    path: { en: "/", fr: "/" },
+    path: { en: "/", fr: "/", de: "/" },
     component: HomePage,
   },
   {
-    path: { en: "/blog/:id", fr: "/blog-fr/:id" },
+    path: { en: "/blog/:id", fr: "/blog-fr/:id", de: "/blog-de/:id" },
     component: ArticlePage,
     props: {
       color: "red",
     },
   },
   {
-    path: { en: "/about", fr: "/a-propos" },
+    path: { en: "/about", fr: "/a-propos", de: "/uber" },
     component: AboutPage,
     children: [
       {
-        path: { en: "/foo", fr: "/foo-fr" },
+        path: { en: "/foo", fr: "/foo-fr", de: "/foo-de" },
         component: FooPage,
       },
       {

--- a/example/pages/AboutPage.tsx
+++ b/example/pages/AboutPage.tsx
@@ -3,7 +3,7 @@ import React, {
   forwardRef,
   useRef
 } from "react";
-import { Router } from "../../src";
+import { langMiddleware, Router } from "../../src";
 import { useStack } from "../../src";
 import { transitionsHelper } from "../helper/transitionsHelper";
 import { Link } from "../../src";
@@ -32,7 +32,10 @@ const AboutPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) => {
           <nav>
             <ul>
               <li>
-                <Link to={`/about/foo`}>Foo</Link>{" "}
+                <Link to={`/about/foo`}>Foo EN</Link>{" "}
+              </li>
+              <li>
+                <Link to={`/a-propos/foo-fr`}>Foo FR</Link>{" "}
               </li>
               <li>
                 <Link to={"/about/bar"}>Bar</Link>{" "}

--- a/example/pages/AboutPage.tsx
+++ b/example/pages/AboutPage.tsx
@@ -3,7 +3,7 @@ import React, {
   forwardRef,
   useRef
 } from "react";
-import { langMiddleware, Router } from "../../src";
+import { Router } from "../../src";
 import { useStack } from "../../src";
 import { transitionsHelper } from "../helper/transitionsHelper";
 import { Link } from "../../src";
@@ -24,6 +24,7 @@ const AboutPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) => {
     playOut: () => transitionsHelper(rootRef.current, false),
   });
 
+
   return (
     <div className={componentName} ref={rootRef}>
       {componentName}
@@ -32,10 +33,7 @@ const AboutPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) => {
           <nav>
             <ul>
               <li>
-                <Link to={`/about/foo`}>Foo EN</Link>{" "}
-              </li>
-              <li>
-                <Link to={`/a-propos/foo-fr`}>Foo FR</Link>{" "}
+                <Link to={{name: "HomePage", params: {lang: "fr"}}}>Foo EN</Link>{" "}
               </li>
               <li>
                 <Link to={"/about/bar"}>Bar</Link>{" "}

--- a/example/pages/AboutPage.tsx
+++ b/example/pages/AboutPage.tsx
@@ -1,8 +1,4 @@
-import React, {
-  ForwardedRef,
-  forwardRef,
-  useRef
-} from "react";
+import React, { ForwardedRef, forwardRef, useRef } from "react";
 import { Router } from "../../src";
 import { useStack } from "../../src";
 import { transitionsHelper } from "../helper/transitionsHelper";
@@ -24,28 +20,24 @@ const AboutPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) => {
     playOut: () => transitionsHelper(rootRef.current, false),
   });
 
-
   return (
     <div className={componentName} ref={rootRef}>
       {componentName}
-      {/*<Router base={"/about"}>*/}
-      {/*  <div className={componentName}>*/}
-      {/*    <nav>*/}
-      {/*      <ul>*/}
-      {/*        <li>*/}
-      {/*          <Link to={{name: "HomePage", params: {lang: "fr"}}}>Foo EN</Link>{" "}*/}
-      {/*        </li>*/}
-      {/*        <li>*/}
-      {/*          <Link to={"/about/bar"}>Bar</Link>{" "}*/}
-      {/*        </li>*/}
-      {/*        <li>*/}
-      {/*          <Link to={`/error`}>NotFound route</Link>{" "}*/}
-      {/*        </li>*/}
-      {/*      </ul>*/}
-      {/*    </nav>*/}
-      {/*    <Stack key={"about-stack"} />*/}
-      {/*  </div>*/}
-      {/*</Router>*/}
+      <Router base={"/about"}>
+        <div className={componentName}>
+          <nav>
+            <ul>
+              <li>
+                <Link to={{ name: "FooPage" }}>Foo</Link>
+              </li>
+              <li>
+                <Link to={{ name: "BarPage" }}>Bar</Link>{" "}
+              </li>
+            </ul>
+          </nav>
+          <Stack key={"about-stack"} />
+        </div>
+      </Router>
     </div>
   );
 });

--- a/example/pages/AboutPage.tsx
+++ b/example/pages/AboutPage.tsx
@@ -28,24 +28,24 @@ const AboutPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) => {
   return (
     <div className={componentName} ref={rootRef}>
       {componentName}
-      <Router base={"/about"}>
-        <div className={componentName}>
-          <nav>
-            <ul>
-              <li>
-                <Link to={{name: "HomePage", params: {lang: "fr"}}}>Foo EN</Link>{" "}
-              </li>
-              <li>
-                <Link to={"/about/bar"}>Bar</Link>{" "}
-              </li>
-              <li>
-                <Link to={`/error`}>NotFound route</Link>{" "}
-              </li>
-            </ul>
-          </nav>
-          <Stack key={"about-stack"} />
-        </div>
-      </Router>
+      {/*<Router base={"/about"}>*/}
+      {/*  <div className={componentName}>*/}
+      {/*    <nav>*/}
+      {/*      <ul>*/}
+      {/*        <li>*/}
+      {/*          <Link to={{name: "HomePage", params: {lang: "fr"}}}>Foo EN</Link>{" "}*/}
+      {/*        </li>*/}
+      {/*        <li>*/}
+      {/*          <Link to={"/about/bar"}>Bar</Link>{" "}*/}
+      {/*        </li>*/}
+      {/*        <li>*/}
+      {/*          <Link to={`/error`}>NotFound route</Link>{" "}*/}
+      {/*        </li>*/}
+      {/*      </ul>*/}
+      {/*    </nav>*/}
+      {/*    <Stack key={"about-stack"} />*/}
+      {/*  </div>*/}
+      {/*</Router>*/}
     </div>
   );
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "size-limit": [
     {
-      "limit": "15 kB",
+      "limit": "16 kB",
       "path": "dist/**/*.js"
     }
   ],

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -16,8 +16,9 @@ const debug = require("debug")("router:CreateRouter");
 
 export type TRoute = {
   path: any;
-  //| { [x: string]: string };
+  // string | { [x: string]: string };
   component?: React.ComponentType<any>;
+  langPath?: { [x: string]: string };
   name?: string;
   parser?: Path;
   props?: {
@@ -263,6 +264,7 @@ export class CreateRouter {
           component: route?.component,
           children: route?.children,
           parser: pPathParser || pathParser,
+          langPath: route.langPath,
           name: route?.name || route?.component?.displayName,
           props: {
             params,

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -15,7 +15,8 @@ import {
 const debug = require("debug")("router:CreateRouter");
 
 export type TRoute = {
-  path: string;
+  path: any;
+  //| { [x: string]: string };
   component: React.ComponentType<any>;
   name?: string;
   parser?: Path;
@@ -112,7 +113,7 @@ export class CreateRouter {
     this.preMiddlewareRoutes = routes.map((route: TRoute) => ({
       ...route,
       name: route?.name || route?.component?.displayName,
-      parser: new Path(route.path),
+      // parser: new Path(route.path),
     }));
 
     debug(this.id, "this.preMiddlewareRoutes", this.preMiddlewareRoutes);

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -11,15 +11,13 @@ import {
   HashHistory,
   MemoryHistory,
 } from "history";
-import { getLangPathByPath } from "../lang/langHelpers";
-import { LangService } from "../index";
 
 const debug = require("debug")("router:CreateRouter");
 
 export type TRoute = {
   path: any;
   //| { [x: string]: string };
-  component: React.ComponentType<any>;
+  component?: React.ComponentType<any>;
   name?: string;
   parser?: Path;
   props?: {

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -24,13 +24,11 @@ export type TRoute = {
     params?: { [x: string]: any };
     [x: string]: any;
   };
-  children?: TRoute[];
-  // local match URL with params (needed by nested router)
-  matchUrl?: string;
-  // full URL who not depend of current instance
-  fullUrl?: string;
-  // full Path /base/:lang/foo/second-foo
+  children?: TRoute[]; // local match URL with params (needed by nested router)
+  url?: string; // full URL who not depend of current instance
+  fullUrl?: string; // full Path /base/:lang/foo/second-foo
   fullPath?: string;
+  base?: string;
 };
 
 export enum EHistoryMode {
@@ -110,12 +108,7 @@ export class CreateRouter {
     }
 
     // format routes
-    this.preMiddlewareRoutes = routes.map((route: TRoute) => ({
-      ...route,
-      name: route?.name || route?.component?.displayName,
-      // parser: new Path(route.path),
-    }));
-
+    this.preMiddlewareRoutes = routes;
     debug(this.id, "this.preMiddlewareRoutes", this.preMiddlewareRoutes);
 
     this.routes =
@@ -123,7 +116,6 @@ export class CreateRouter {
         (routes, middleware) => middleware(routes),
         this.preMiddlewareRoutes
       ) || this.preMiddlewareRoutes;
-
     debug(this.id, "this.routes", this.routes);
 
     this.updateRoute();
@@ -195,10 +187,7 @@ export class CreateRouter {
       return;
     }
 
-    if (
-      this.currentRoute?.matchUrl != null &&
-      this.currentRoute?.matchUrl === matchingRoute?.matchUrl
-    ) {
+    if (this.currentRoute?.url != null && this.currentRoute?.url === matchingRoute?.url) {
       debug(this.id, "updateRoute: THIS IS THE SAME URL, RETURN.");
       return;
     }
@@ -254,14 +243,15 @@ export class CreateRouter {
         const route = pCurrentRoute || currentRoute;
         const params = pMatch || match;
         const routeObj = {
-          fullUrl: pUrl,
           fullPath: currentRoutePath,
-          matchUrl: buildUrl(route.path, params),
           path: route?.path,
+          fullUrl: pUrl,
+          url: buildUrl(route.path, params),
+          base: pBase,
           component: route?.component,
           children: route?.children,
           parser: pPathParser || pathParser,
-          name: route?.name,
+          name: route?.name || route?.component?.displayName,
           props: {
             params,
             ...(route?.props || {}),

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -11,6 +11,8 @@ import {
   HashHistory,
   MemoryHistory,
 } from "history";
+import { getLangPathByPath } from "../lang/langHelpers";
+import { LangService } from "../index";
 
 const debug = require("debug")("router:CreateRouter");
 
@@ -101,14 +103,8 @@ export class CreateRouter {
       ROUTERS.locationsHistory.push(ROUTERS.history.location);
     }
 
-    // patch: create root route object with path '/' if doesn't exist
-    const rootPathExist = routes.some((route) => route.path === "/");
-    if (!rootPathExist) {
-      routes.push({ path: "/", component: null });
-    }
-
-    // format routes
-    this.preMiddlewareRoutes = routes;
+    // add missing "/" route to routes list if doesn't exist
+    this.preMiddlewareRoutes = this.patchMissingRootRoute(routes);
     debug(this.id, "this.preMiddlewareRoutes", this.preMiddlewareRoutes);
 
     this.routes =
@@ -120,6 +116,24 @@ export class CreateRouter {
 
     this.updateRoute();
     this.initEvents();
+  }
+
+  /**
+   * Patch missing root route
+   * add missing "/" route to routes list if doesn't exist
+   * @param routes
+   */
+  protected patchMissingRootRoute(routes: TRoute[]): TRoute[] {
+    const rootPathExist = routes.some(
+      (route) =>
+        (typeof route.path === "object" &&
+          Object.keys(route.path).some((el) => route.path[el] === "/")) ||
+        route.path === "/"
+    );
+    if (!rootPathExist) {
+      routes.push({ path: "/", component: null });
+    }
+    return routes;
   }
 
   /**

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -14,22 +14,29 @@ import {
 
 const debug = require("debug")("router:CreateRouter");
 
+export type TParams = {
+  [x: string]: any;
+};
+
+export type TProps = {
+  params?: TParams;
+  [x: string]: any;
+};
+
+export type TPathLangObject = { [x: string]: string };
+
 export type TRoute = {
-  path: any;
-  // string | { [x: string]: string };
+  path: string | TPathLangObject;
   component?: React.ComponentType<any>;
-  langPath?: { [x: string]: string } | null;
+  base?: string;
   name?: string;
   parser?: Path;
-  props?: {
-    params?: { [x: string]: any };
-    [x: string]: any;
-  };
-  children?: TRoute[]; // local match URL with params (needed by nested router)
-  url?: string; // full URL who not depend of current instance
-  fullUrl?: string; // full Path /base/:lang/foo/second-foo
-  fullPath?: string;
-  base?: string;
+  props?: TProps;
+  children?: TRoute[];
+  url?: string;
+  fullUrl?: string; // full URL who not depend of current instance
+  fullPath?: string; // full Path /base/:lang/foo/second-foo
+  langPath?: { [x: string]: string } | null;
 };
 
 export enum EHistoryMode {
@@ -50,26 +57,21 @@ export enum ERouterEvent {
 export class CreateRouter {
   // base URL
   public base: string;
-  // routes list
+  // before execute middleware routes list
   public preMiddlewareRoutes: TRoute[] = [];
+  // routes list
   public routes: TRoute[] = [];
-
   // middlewares list to exectute in specific order
   public middlewares: any[];
-
   // create event emitter
   public events: EventEmitter = new EventEmitter();
-
   // current / previous route object
   public currentRoute: TRoute;
   public previousRoute: TRoute;
-
   // history mode choice used by history library›
   public historyMode: EHistoryMode;
-
   // store history listener
   protected unlistenHistory;
-
   // router instance ID, useful for debug if there is multiple router instance
   public id: number | string;
 
@@ -242,7 +244,7 @@ export class CreateRouter {
     // test each routes
     for (let currentRoute of pRoutes) {
       // create parser & matcher
-      const currentRoutePath = joinPaths([pBase, currentRoute.path]);
+      const currentRoutePath = joinPaths([pBase, currentRoute.path as string]);
       // prepare parser
       const pathParser: Path = new Path(currentRoutePath);
       // prettier-ignore
@@ -258,7 +260,7 @@ export class CreateRouter {
           fullPath: currentRoutePath,
           path: route?.path,
           fullUrl: pUrl,
-          url: buildUrl(route.path, params),
+          url: buildUrl(route.path as string, params),
           base: pBase,
           component: route?.component,
           children: route?.children,

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -240,8 +240,7 @@ export class CreateRouter {
     let match;
 
     // test each routes
-    for (let i in pRoutes) {
-      let currentRoute = pRoutes[i];
+    for (let currentRoute of pRoutes) {
       // create parser & matcher
       const currentRoutePath = joinPaths([pBase, currentRoute.path]);
       // prepare parser

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -130,7 +130,7 @@ export class CreateRouter {
         route.path === "/"
     );
     if (!rootPathExist) {
-      routes.push({ path: "/", component: null });
+      routes.unshift({ path: "/", component: null });
     }
     return routes;
   }

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -18,7 +18,7 @@ export type TRoute = {
   path: any;
   // string | { [x: string]: string };
   component?: React.ComponentType<any>;
-  langPath?: { [x: string]: string };
+  langPath?: { [x: string]: string } | null;
   name?: string;
   parser?: Path;
   props?: {

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -63,17 +63,27 @@ export function buildUrl(path: string, params?: TParams): string {
  */
 export function getUrlByPath(
   routes: TRoute[],
-  path: string,
+  path: string | { [x: string]: string },
   basePath: string = null
 ): string {
   // prepare local path
   let localPath: string[] = [basePath];
 
   for (let route of routes) {
+    const routePath =
+      route.langPath?.[LangService.currentLang?.key] ||
+      route.path;
+
+    const oneMatch = Object.keys(route.langPath).some(l => route.langPath[l] === path)
+     if (oneMatch) {
+       debug('route> true')
+     }
+
+    debug("route>", route, path)
     // if path match on first level
-    if (route.path === path) {
+    if (oneMatch) {
       // keep path in local array
-      localPath.push(route.path);
+      localPath.push(routePath);
       // return it
       return joinPaths(localPath);
     }
@@ -85,7 +95,7 @@ export function getUrlByPath(
       // return recursive Fn only if match, else continue to next iteration
       if (matchChildrenPath) {
         // keep path in local array
-        localPath.push(route.path);
+        localPath.push(routePath);
         // Return the function after localPath push
         return getUrlByPath(route.children, path, joinPaths(localPath));
       }

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -69,9 +69,7 @@ export function getUrlByPath(
   // prepare local path
   let localPath: string[] = [basePath];
 
-  for (let i in routes) {
-    const route = routes[i];
-
+  for (let route of routes) {
     // if path match on first level
     if (route.path === path) {
       // keep path in local array
@@ -103,8 +101,7 @@ export function getUrlByRouteName(pRoutes: TRoute[], pParams: TOpenRouteParams):
   // need to wrap the function to be able to access the preserved "pRoutes" param
   // in local scope after recursion
   const recursiveFn = (routes: TRoute[], params: TOpenRouteParams): string => {
-    for (let i in routes) {
-      const route = routes[i];
+    for (let route of routes) {
       const match =
         route?.name === params.name || route.component?.displayName === params.name;
       if (match) {

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -71,7 +71,7 @@ export function getUrlByPathPart(
 
   for (let route of routes) {
     const langPath = route.langPath?.[lang];
-    const routePath = route.path;
+    const routePath = route.path as string;
     const pathMatch = langPath === path || routePath === path;
 
     // if path match on first level, keep path in local array and return it, stop here.

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -56,12 +56,12 @@ export function buildUrl(path: string, params?: TParams): string {
 }
 
 /**
- * Get URL by path
+ * Get URL by path part
  *  if path "/foo" is a children of path "/bar", his full url is "/bar/foo"
  *  With "/foo" this function will return "/bar/foo"
  * @returns string
  */
-export function getUrlByPath(
+export function getUrlByPathPart(
   routes: TRoute[],
   path: string | { [x: string]: string },
   lang: string,
@@ -76,7 +76,6 @@ export function getUrlByPath(
 
     // if path match on first level, keep path in local array and return it, stop here.
     if (pathMatch) {
-      debug("route > pathMatch", { path, langPath, routePath, pathMatch });
       localPath.push(langPath || routePath);
       return joinPaths(localPath);
     }
@@ -84,7 +83,7 @@ export function getUrlByPath(
     // if not matching but as children, return it
     else if (route?.children?.length > 0) {
       // no match, recall recursively on children
-      const matchChildrenPath = getUrlByPath(
+      const matchChildrenPath = getUrlByPathPart(
         route.children,
         path,
         lang,
@@ -95,7 +94,7 @@ export function getUrlByPath(
         // keep path in local array
         localPath.push(langPath || routePath);
         // Return the function after localPath push
-        return getUrlByPath(route.children, path, lang, joinPaths(localPath));
+        return getUrlByPathPart(route.children, path, lang, joinPaths(localPath));
       }
     }
   }
@@ -121,8 +120,7 @@ export function getUrlByRouteName(pRoutes: TRoute[], pParams: TOpenRouteParams):
           return;
         }
         // get full URL
-        const urlByPath = getUrlByPath(pRoutes, route.path, pParams?.params?.lang);
-        debug("urlByPath", urlByPath);
+        const urlByPath = getUrlByPathPart(pRoutes, route.path, pParams?.params?.lang);
         // build URL with param and return
         return buildUrl(urlByPath, params.params);
       }
@@ -186,11 +184,15 @@ export function addBaseToUrl(url: string, base = useRootRouter()?.base): string 
 }
 
 /**
- * Return path without his base
+ * Return path without his URL
+ *
+ * before: "/custom-base/foo"
+ * after:  "/foo"
+ *
  * @param path
  * @param base
  */
-export function extractPathFromBase(path: string, base: string): string {
+export function removeBaseToUrl(path: string, base: string): string {
   let baseStartIndex = path.indexOf(base);
   return baseStartIndex == 0 ? path.substr(base.length, path.length) : path;
 }

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -93,7 +93,7 @@ export function getUrlByPath(
       // return recursive Fn only if match, else continue to next iteration
       if (matchChildrenPath) {
         // keep path in local array
-        localPath.push(routePath);
+        localPath.push(langPath || routePath);
         // Return the function after localPath push
         return getUrlByPath(route.children, path, lang, joinPaths(localPath));
       }

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -64,7 +64,7 @@ export function buildUrl(path: string, params?: TParams): string {
 export function getUrlByPathPart(
   routes: TRoute[],
   path: string | { [x: string]: string },
-  lang: string,
+  lang: string = LangService.currentLang?.key || undefined,
   basePath: string = null
 ): string {
   let localPath: string[] = [basePath];

--- a/src/api/routers.ts
+++ b/src/api/routers.ts
@@ -2,6 +2,8 @@ import { CreateRouter, TRoute } from "./CreateRouter";
 import { BrowserHistory, HashHistory, MemoryHistory } from "history";
 
 export type TRoutersConfig = {
+
+  preMiddelwareRoutes: TRoute[]
   /**
    * Global routes list
    */
@@ -34,6 +36,7 @@ export type TRoutersConfig = {
  * This object values do not depend of one single router
  */
 export const ROUTERS: TRoutersConfig = {
+  preMiddelwareRoutes: null,
   routes: null,
   instances: [],
   history: null,

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useMemo } from "react";
 import { prepareSetLocationUrl, useLocation } from "..";
 import { joinPaths, TOpenRouteParams } from "../api/helpers";
-import { getLangPathByPath } from "../lang/langHelpers";
 
 interface IProps {
   to: string | TOpenRouteParams;
@@ -23,10 +22,7 @@ function Link(props: IProps) {
   const handleClick = (e) => {
     e.preventDefault();
     props.onClick?.();
-    setLocation(
-      props.to
-      //typeof props.to === "string" ? getLangPathByPath(props.to) : props.to
-    );
+    setLocation(props.to);
   };
 
   return (

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useMemo } from "react";
 import { prepareSetLocationUrl, useLocation } from "..";
 import { joinPaths, TOpenRouteParams } from "../api/helpers";
+import { getLangPathByPath } from "../lang/langHelpers";
 
 interface IProps {
   to: string | TOpenRouteParams;
@@ -22,7 +23,10 @@ function Link(props: IProps) {
   const handleClick = (e) => {
     e.preventDefault();
     props.onClick?.();
-    setLocation(props.to);
+    setLocation(
+      props.to
+      //typeof props.to === "string" ? getLangPathByPath(props.to) : props.to
+    );
   };
 
   return (

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useMemo } from "react";
 import { prepareSetLocationUrl, useLocation } from "..";
-import { joinPaths, TOpenRouteParams } from "../api/helpers";
+import { joinPaths, removeLastCharFromString, TOpenRouteParams } from "../api/helpers";
 
 interface IProps {
   to: string | TOpenRouteParams;
@@ -17,7 +17,10 @@ function Link(props: IProps) {
 
   const url = useMemo(() => prepareSetLocationUrl(props.to), [props.to]);
 
-  const isActive = useMemo(() => location === url, [location, url]);
+  const isActive = useMemo(
+    () => location === url || location === removeLastCharFromString(url, "/", true),
+    [location, url]
+  );
 
   const handleClick = (e) => {
     e.preventDefault();

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -10,9 +10,10 @@ import React, {
 import { joinPaths } from "../api/helpers";
 import { ROUTERS } from "../api/routers";
 import { LangService } from "..";
+import { getLangPathByPath } from "../lang/langHelpers";
 
 const componentName = "Router";
-// const debug = require("debug")(`router:${componentName}`);
+const debug = require("debug")(`router:${componentName}`);
 
 interface IProps {
   base: string;
@@ -59,7 +60,7 @@ export const Router = memo((props: IProps) => {
       currentRoutesList = props.routes;
     } else {
       currentRoutesList = ROUTERS.routes?.find((el) => {
-        return `${el.path}` === props.base;
+        return getLangPathByPath(el.path) === getLangPathByPath(props.base);
       })?.children;
     }
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -46,7 +46,7 @@ export const Router = memo((props: IProps) => {
   // join each parent router base
   const base = joinPaths([
     parentRouter?.base,
-    // because language middleware nedd to patch only first level routes
+    // because language middleware need to patch only first level routes
     id !== 1 && showLang && "/:lang",
     props.base,
   ]);
@@ -63,12 +63,8 @@ export const Router = memo((props: IProps) => {
         return getLangPathByPath(el.path) === getLangPathByPath(props.base);
       })?.children;
     }
-
     return currentRoutesList;
   }, [props.routes, props.base]);
-
-  // middlewares are properties of root instance only?
-  const middlewares = props.middlewares;
 
   // keep router instance in state
   const [routerState] = useState<CreateRouter>(() => {
@@ -76,7 +72,7 @@ export const Router = memo((props: IProps) => {
       base,
       routes,
       id,
-      middlewares,
+      middlewares: props.middlewares,
       historyMode: props.historyMode,
     });
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -51,7 +51,7 @@ export const Router = memo((props: IProps) => {
     } else {
       debug(id, ROUTERS.routes);
       currentRoutesList = ROUTERS.routes?.find((el) => {
-        return getLangPathByPath(el.path) === getLangPathByPath(props.base);
+        return getLangPathByPath({ path: el.path }) === getLangPathByPath({ path: props.base });
       })?.children;
 
       debug(currentRoutesList);
@@ -69,7 +69,7 @@ export const Router = memo((props: IProps) => {
   const base = useMemo(() => {
     const parentBase: string = parentRouter?.base;
     const addLang: boolean = id !== 1 && showLang;
-    const base: string = addLang ? getLangPathByPath(props.base) : props.base;
+    const base: string = addLang ? getLangPathByPath({ path: props.base }) : props.base;
     return joinPaths([
       parentBase, // ex: /master-base
       addLang && "/:lang",

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -55,14 +55,12 @@ export const Router = memo((props: IProps) => {
       })?.children;
 
       debug(currentRoutesList);
-      // patch pre
       if (LangService.isInit) {
+        // If sub router, need to selected appropriate route path by lang
         currentRoutesList = langMiddleware(currentRoutesList, false);
       }
     }
-
     debug(currentRoutesList);
-
     return currentRoutesList;
   }, [props.routes, props.base]);
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -37,10 +37,8 @@ RouterContext.displayName = componentName;
 export const Router = memo((props: IProps) => {
   // deduce a router ID
   const id = ROUTERS.instances?.length > 0 ? ROUTERS.instances.length + 1 : 1;
-
   // get parent router instance if exist, in case we are one sub router
   const parentRouter = useRouter();
-
   // get routes list by props first
   // if there is no props.routes, we deduce that we are on a subrouter
   const routes = useMemo(() => {
@@ -51,7 +49,9 @@ export const Router = memo((props: IProps) => {
     } else {
       debug(id, ROUTERS.routes);
       currentRoutesList = ROUTERS.routes?.find((el) => {
-        return getLangPathByPath({ path: el.path }) === getLangPathByPath({ path: props.base });
+        return (
+          getLangPathByPath({ path: el.path }) === getLangPathByPath({ path: props.base })
+        );
       })?.children;
 
       debug(currentRoutesList);
@@ -79,8 +79,6 @@ export const Router = memo((props: IProps) => {
 
   // keep router instance in state
   const [routerState] = useState<CreateRouter>(() => {
-    debug("routes", routes);
-
     const newRouter = new CreateRouter({
       base,
       routes,

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -47,20 +47,16 @@ export const Router = memo((props: IProps) => {
       ROUTERS.routes = props.routes;
       currentRoutesList = props.routes;
     } else {
-      debug(id, ROUTERS.routes);
       currentRoutesList = ROUTERS.routes?.find((el) => {
         return (
           getLangPathByPath({ path: el.path }) === getLangPathByPath({ path: props.base })
         );
       })?.children;
-
-      debug(currentRoutesList);
       if (LangService.isInit) {
         // If sub router, need to selected appropriate route path by lang
         currentRoutesList = langMiddleware(currentRoutesList, false);
       }
     }
-    debug(currentRoutesList);
     return currentRoutesList;
   }, [props.routes, props.base]);
 

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -16,6 +16,7 @@ const debug = require("debug")(`router:useLocation`);
  */
 export const prepareSetLocationUrl = (args: string | TOpenRouteParams): string => {
   const rootRouter = useRootRouter();
+
   let urlToPush: string;
 
   // in case we recieve a string

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -33,6 +33,7 @@ export const prepareSetLocationUrl = (args: string | TOpenRouteParams): string =
       };
     }
 
+    debug('rootRouter.routes',rootRouter.routes)
     // Get URL by the route name
     urlToPush = getUrlByRouteName(rootRouter.routes, args);
 

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -8,6 +8,7 @@ import {
 } from "../api/helpers";
 import { ROUTERS } from "../api/routers";
 import { LangService } from "..";
+const debug = require("debug")(`router:useLocation`);
 
 /**
  * Prepare setLocation URL

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -26,6 +26,8 @@ export const prepareSetLocationFullUrl = (
   let pathToGenerate = [];
 
   for (let instance of instances) {
+    debug('instance.currentRoute.name',instance.currentRoute?.name)
+
     const newUrl = prepareSetLocationUrl({
       name: instance.currentRoute.name,
       params: {

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -29,7 +29,7 @@ export const prepareSetLocationFullUrl = (
     const newUrl = prepareSetLocationUrl({
       name: instance.currentRoute.name,
       params: {
-        ...instance.currentRoute.props.params,
+        ...(instance.currentRoute.props?.params || {}),
         lang: toLang.key,
       },
     });

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useHistory, useRootRouter } from "..";
+import { CreateRouter, useHistory, useRootRouter } from "..";
 import {
   addBaseToUrl,
   addLangToUrl,
@@ -9,6 +9,35 @@ import {
 import { ROUTERS } from "../api/routers";
 import { LangService } from "..";
 const debug = require("debug")(`router:useLocation`);
+
+/**
+ * prepare set location new URL
+ * ex:
+ *   "/base/en/foo-en-path/sub-en-path"
+ * should become:
+ *   "/base/fr/foo-fr-path/sub-fr-path"
+ *
+ *
+ */
+export const prepareSetLocationFullUrl = (
+  toLang,
+  instances: CreateRouter[] = ROUTERS.instances
+) => {
+  let pathToGenerate = [];
+
+  for (let instance of instances) {
+    const newUrl = prepareSetLocationUrl({
+      name: instance.currentRoute.name,
+      params: {
+        ...instance.currentRoute.props.params,
+        lang: toLang.key,
+      },
+    });
+    pathToGenerate.push(newUrl);
+  }
+  // get last item of array
+  return pathToGenerate.filter((v) => v).slice(-1)[0];
+};
 
 /**
  * Prepare setLocation URL
@@ -21,7 +50,7 @@ export const prepareSetLocationUrl = (args: string | TOpenRouteParams): string =
 
   // in case we recieve a string
   if (typeof args === "string") {
-    urlToPush = args;
+    urlToPush = args as string;
     urlToPush = addLangToUrl(urlToPush);
 
     // in case we recieve an object
@@ -32,14 +61,12 @@ export const prepareSetLocationUrl = (args: string | TOpenRouteParams): string =
         ...{ lang: LangService.currentLang.key },
       };
     }
-
-    debug('rootRouter.routes',rootRouter.routes)
     // Get URL by the route name
     urlToPush = getUrlByRouteName(rootRouter.routes, args);
 
     // in other case return.
   } else {
-    console.warn("setLocation param isn't valid. return.");
+    console.warn("setLocation param isn't valid. return.", args);
     return;
   }
 

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -26,8 +26,6 @@ export const prepareSetLocationFullUrl = (
   let pathToGenerate = [];
 
   for (let instance of instances) {
-    debug('instance.currentRoute.name',instance.currentRoute?.name)
-
     const newUrl = prepareSetLocationUrl({
       name: instance.currentRoute.name,
       params: {

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -12,11 +12,11 @@ const debug = require("debug")(`router:useLocation`);
 
 /**
  * prepare set location new URL
+ *
  * ex:
  *   "/base/en/foo-en-path/sub-en-path"
  * should become:
  *   "/base/fr/foo-fr-path/sub-fr-path"
- *
  *
  */
 export const prepareSetLocationFullUrl = (

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -1,5 +1,7 @@
 import { LangService, TRoute } from "..";
 import { joinPaths } from "../api/helpers";
+import { selectLangPathByLang } from "./langHelpers";
+const debug = require("debug")("router:LanguagesMiddleware");
 
 /**
  * LanguagesMiddleware
@@ -12,8 +14,13 @@ export const langMiddleware = (
   enable = LangService.showLangInUrl()
 ): TRoute[] => {
   if (!enable) return pRoutes;
-  return pRoutes.map((route: TRoute) => ({
-    ...route,
-    path: joinPaths(["/:lang", route.path !== "/" ? route.path : ""]),
-  }));
+
+  debug("langMiddleware: current lang", LangService.currentLang);
+  return pRoutes.map((route: TRoute) => {
+    const path = selectLangPathByLang(route);
+    return {
+      ...route,
+      path: joinPaths(["/:lang", path !== "/" ? path : ""]),
+    };
+  });
 };

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -7,49 +7,41 @@ const debug = require("debug")("router:LanguagesMiddleware");
  * LanguagesMiddleware
  * Patch all routes with ":lang" param
  * @param routes
- * @param enable
+ * @param showLangInUrl
  */
 export const langMiddleware = (
   routes: TRoute[],
-  enable = LangService.showLangInUrl()
+  showLangInUrl = LangService.showLangInUrl()
 ): TRoute[] => {
-  if (!enable) return routes;
+  // return routes if langService is not init
+  if (!LangService.isInit) return routes;
 
   /**
-   * format path recurcively (on chidren if exist)
+   *  - Add "/:lang" param on each 1st level route
+   *  - format path recurcively (on chidren if exist)
    * ex:
    *   [
    *     { path: { en: "/", fr: "/" } },
    *     { path: { en: "/news", fr: "/actu" } }
    *   ]
    *
-   *   return:
-   *
-   *     { path: en: "/" },
-   *     { path: en: "/news" },
-   *
-   *
-   * @param routes
+   *  return:
+   *    { path: en: "/" },
+   *    { path: en: "/news" },
    */
-  const recursiveFormatPath = (routes: TRoute[]) => {
-    for (let route of routes) {
-      if (route.path) route.path = getLangPathByLang(route);
-      if (route.children?.length > 0) {
-        recursiveFormatPath(route.children);
-      }
-    }
+
+  const patchRoutes = (pRoutes, children = false) => {
+    return pRoutes.map((route: TRoute) => {
+      const path = getLangPathByLang(route);
+      const hasChildren = route.children?.length > 0;
+      const showLang = !children && showLangInUrl;
+      return {
+        ...route,
+        path: joinPaths([showLang && "/:lang", path !== "/" ? path : ""]),
+        ...(hasChildren ? { children: patchRoutes(route.children, true) } : {}),
+      };
+    });
   };
-  recursiveFormatPath(routes);
 
-  /**
-   * Add "/:lang" param on each 1st level route
-   */
-  const patchLangParam = (routes) =>
-    routes.map((route: TRoute) => ({
-      ...route,
-      path: joinPaths(["/:lang", route.path !== "/" ? route.path : ""]),
-    }));
-
-  // return formated routes
-  return patchLangParam(routes);
+  return patchRoutes(routes);
 };

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -1,6 +1,6 @@
 import { LangService, TRoute } from "..";
 import { joinPaths } from "../api/helpers";
-import { selectLangPathByLang } from "./langHelpers";
+import { getLangPathByLang } from "./langHelpers";
 const debug = require("debug")("router:LanguagesMiddleware");
 
 /**
@@ -14,10 +14,8 @@ export const langMiddleware = (
   enable = LangService.showLangInUrl()
 ): TRoute[] => {
   if (!enable) return pRoutes;
-
-  debug("langMiddleware: current lang", LangService.currentLang);
   return pRoutes.map((route: TRoute) => {
-    const path = selectLangPathByLang(route);
+    const path = getLangPathByLang(route);
     return {
       ...route,
       path: joinPaths(["/:lang", path !== "/" ? path : ""]),

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -26,8 +26,8 @@ export const langMiddleware = (
    *   ]
    *
    *  return:
-   *    { path: en: "/" },
-   *    { path: en: "/news" },
+   *    { path: "/" },
+   *    { path: "/news" },
    */
 
   const patchRoutes = (pRoutes, children = false) => {

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -6,19 +6,50 @@ const debug = require("debug")("router:LanguagesMiddleware");
 /**
  * LanguagesMiddleware
  * Patch all routes with ":lang" param
- * @param pRoutes
+ * @param routes
  * @param enable
  */
 export const langMiddleware = (
-  pRoutes: TRoute[],
+  routes: TRoute[],
   enable = LangService.showLangInUrl()
 ): TRoute[] => {
-  if (!enable) return pRoutes;
-  return pRoutes.map((route: TRoute) => {
-    const path = getLangPathByLang(route);
-    return {
+  if (!enable) return routes;
+
+  /**
+   * format path recurcively (on chidren if exist)
+   * ex:
+   *   [
+   *     { path: { en: "/", fr: "/" } },
+   *     { path: { en: "/news", fr: "/actu" } }
+   *   ]
+   *
+   *   return:
+   *
+   *     { path: en: "/" },
+   *     { path: en: "/news" },
+   *
+   *
+   * @param routes
+   */
+  const recursiveFormatPath = (routes: TRoute[]) => {
+    for (let route of routes) {
+      if (route.path) route.path = getLangPathByLang(route);
+      if (route.children?.length > 0) {
+        recursiveFormatPath(route.children);
+      }
+    }
+  };
+  recursiveFormatPath(routes);
+
+  /**
+   * Add "/:lang" param on each 1st level route
+   */
+  const patchLangParam = (routes) =>
+    routes.map((route: TRoute) => ({
       ...route,
-      path: joinPaths(["/:lang", path !== "/" ? path : ""]),
-    };
-  });
+      path: joinPaths(["/:lang", route.path !== "/" ? route.path : ""]),
+    }));
+
+  // return formated routes
+  return patchLangParam(routes);
 };

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -17,27 +17,46 @@ export const langMiddleware = (
   if (!LangService.isInit) return routes;
 
   /**
+   * Add :lang param on path
+   * @param pPath
+   * @param pShowLang
+   */
+  const patchLangParam = (pPath: string, pShowLang): string =>
+    joinPaths([pShowLang && "/:lang", pPath !== "/" ? pPath : ""]);
+
+  /**
+   * Patch routes
    *  - Add "/:lang" param on each 1st level route
    *  - format path recurcively (on chidren if exist)
    * ex:
-   *   [
-   *     { path: { en: "/", fr: "/" } },
-   *     { path: { en: "/news", fr: "/actu" } }
-   *   ]
+   *     {
+   *      path: { en: "/home", fr: "/accueil" }
+   *     },
    *
    *  return:
-   *    { path: "/" },
-   *    { path: "/news" },
-   */
+   *    {
+   *      path: "/:lang/home",
+   *      langPath: { en: "/:lang/home", fr: "/:lang/accueil" },
+   *    }
 
+   *
+   */
   const patchRoutes = (pRoutes, children = false) => {
     return pRoutes.map((route: TRoute) => {
       const path = getLangPathByLang(route);
       const hasChildren = route.children?.length > 0;
       const showLang = !children && showLangInUrl;
+
+      let langPath = {};
+      typeof route.path === "object" &&
+        Object.keys(route.path).forEach((lang) => {
+          langPath[lang] = patchLangParam(route.path[lang], showLang);
+        });
+
       return {
         ...route,
-        path: joinPaths([showLang && "/:lang", path !== "/" ? path : ""]),
+        path: patchLangParam(path, showLang),
+        langPath: Object.entries(langPath).length !== 0 && langPath,
         ...(hasChildren ? { children: patchRoutes(route.children, true) } : {}),
       };
     });

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -56,7 +56,7 @@ export const langMiddleware = (
       return {
         ...route,
         path: patchLangParam(path, showLang),
-        langPath: Object.entries(langPath).length !== 0 && langPath,
+        langPath: Object.entries(langPath).length !== 0 ? langPath : null,
         ...(hasChildren ? { children: patchRoutes(route.children, true) } : {}),
       };
     });

--- a/src/lang/LangMiddleware.ts
+++ b/src/lang/LangMiddleware.ts
@@ -22,7 +22,7 @@ export const langMiddleware = (
    * @param pShowLang
    */
   const patchLangParam = (pPath: string, pShowLang): string =>
-    joinPaths([pShowLang && "/:lang", pPath !== "/" ? pPath : ""]);
+    joinPaths([pShowLang && "/:lang", pPath !== "/" ? pPath : "/"]);
 
   /**
    * Patch routes

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -119,9 +119,9 @@ class LangService {
       // register current langage (usefull only if we don't reload the app.)
       this.currentLang = toLang;
 
+      return;
       // reload application
       this.reloadOrRefresh(newUrl, forcePageReload);
-      return;
     }
 
     // if other, case default language need to be hidden from URL

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -6,6 +6,7 @@ import {
   removeLastCharFromString,
 } from "../api/helpers";
 import { useRootRouter } from "../hooks/useRouter";
+import { prepareSetLocationUrl } from "../hooks/useLocation";
 const debug = require("debug")(`router:LangService`);
 
 export type TLanguage = {
@@ -105,11 +106,15 @@ class LangService {
       // /master/:lang/blog/:id
 
       const getPathFromFullPath = fullPath.replace(`${currentRoute.base}/:lang`, "");
-      debug("formatFullPath", getPathFromFullPath);
 
-      // replace:  blog/:id ----> blog-fr/:id
-      // get current path with current lang
-      // replace by path[toLang.key]
+      const pre = prepareSetLocationUrl({
+        name: currentRoute.name,
+        params: {
+          lang: toLang.key,
+        },
+      });
+
+      debug("trace: pre", pre);
 
       const newUrl = buildUrl(fullPath, {
         ...currentRoute?.props?.params,

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -219,7 +219,6 @@ class LangService {
     return this.languages.find((language) => {
       return firstPart === language.key;
     });
-
   }
 
   /**

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -90,7 +90,9 @@ class LangService {
 
     const rootRouter = useRootRouter();
     const currentRoute = rootRouter.currentRoute;
+    debug("ROUTERS.instances", ROUTERS.instances);
     const lastInstance = ROUTERS.instances?.[ROUTERS.instances?.length - 1];
+    debug("ROUTERS.instances -1", lastInstance);
     let fullPath = lastInstance?.currentRoute?.fullPath || "/:lang";
     let path = lastInstance?.currentRoute?.path;
 
@@ -106,11 +108,10 @@ class LangService {
       debug("formatFullPath", getPathFromFullPath);
 
       // replace:  blog/:id ----> blog-fr/:id
-
       // get current path with current lang
       // replace by path[toLang.key]
 
-      //return;
+      return;
       const newUrl = buildUrl(fullPath, {
         ...currentRoute?.props?.params,
         lang: toLang.key,

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -111,7 +111,6 @@ class LangService {
       // get current path with current lang
       // replace by path[toLang.key]
 
-      return;
       const newUrl = buildUrl(fullPath, {
         ...currentRoute?.props?.params,
         lang: toLang.key,

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -90,13 +90,27 @@ class LangService {
 
     const rootRouter = useRootRouter();
     const currentRoute = rootRouter.currentRoute;
-    const instances = ROUTERS.instances;
-    let fullPath = instances?.[instances?.length - 1]?.currentRoute?.fullPath || "/:lang";
+    const lastInstance = ROUTERS.instances?.[ROUTERS.instances?.length - 1];
+    let fullPath = lastInstance?.currentRoute?.fullPath || "/:lang";
+    let path = lastInstance?.currentRoute?.path;
 
     // if default language should be visible in URL, use history push
     if (this.showDefaultLangInUrl) {
       // default language should be always visible in URL, set new /:lang
       fullPath = removeLastCharFromString(fullPath, "/", true);
+
+      debug("fullPath", fullPath, currentRoute);
+      // /master/:lang/blog/:id
+
+      const getPathFromFullPath = fullPath.replace(`${currentRoute.base}/:lang`, "");
+      debug("formatFullPath", getPathFromFullPath);
+
+      // replace:  blog/:id ----> blog-fr/:id
+
+      // get current path with current lang
+      // replace by path[toLang.key]
+
+      //return;
       const newUrl = buildUrl(fullPath, {
         ...currentRoute?.props?.params,
         lang: toLang.key,

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -91,9 +91,7 @@ class LangService {
 
     const rootRouter = useRootRouter();
     const currentRoute = rootRouter.currentRoute;
-    debug("ROUTERS.instances", ROUTERS.instances);
     const lastInstance = ROUTERS.instances?.[ROUTERS.instances?.length - 1];
-    debug("ROUTERS.instances -1", lastInstance);
     let fullPath = lastInstance?.currentRoute?.fullPath || "/:lang";
     let path = lastInstance?.currentRoute?.path;
 
@@ -102,28 +100,25 @@ class LangService {
       // default language should be always visible in URL, set new /:lang
       fullPath = removeLastCharFromString(fullPath, "/", true);
 
-      debug("fullPath", fullPath, currentRoute);
-      // /master/:lang/blog/:id
+      debug("currentRoute", currentRoute);
 
-      const getPathFromFullPath = fullPath.replace(`${currentRoute.base}/:lang`, "");
-
-      const pre = prepareSetLocationUrl({
+      const newUrl = prepareSetLocationUrl({
         name: currentRoute.name,
         params: {
           lang: toLang.key,
         },
       });
+      // const newUrl = buildUrl(currentRoute.langPath[toLang.key], {
+      //   ...currentRoute?.props?.params,
+      //   lang: toLang.key,
+      // });
 
-      debug("trace: pre", pre);
-
-      const newUrl = buildUrl(fullPath, {
-        ...currentRoute?.props?.params,
-        lang: toLang.key,
-      });
+      debug("prepareSetLocationUrl", newUrl);
 
       // register current langage (usefull only if we don't reload the app.)
       this.currentLang = toLang;
 
+      // // TODO remove
       return;
       // reload application
       this.reloadOrRefresh(newUrl, forcePageReload);

--- a/src/lang/LangService.ts
+++ b/src/lang/LangService.ts
@@ -95,33 +95,24 @@ class LangService {
     let fullPath = lastInstance?.currentRoute?.fullPath || "/:lang";
     let path = lastInstance?.currentRoute?.path;
 
-    // if default language should be visible in URL, use history push
+    // if default language should be always visible in URL
     if (this.showDefaultLangInUrl) {
-      // default language should be always visible in URL, set new /:lang
-      fullPath = removeLastCharFromString(fullPath, "/", true);
-
-      debug("currentRoute", currentRoute);
-
+      // prepare new URL
+      // ex:
+      //   "/base/en/foo-en"
+      // should become:
+      //   "/base/fr/foo-fr"
       const newUrl = prepareSetLocationUrl({
         name: currentRoute.name,
         params: {
+          ...currentRoute.props.params,
           lang: toLang.key,
         },
       });
-      // const newUrl = buildUrl(currentRoute.langPath[toLang.key], {
-      //   ...currentRoute?.props?.params,
-      //   lang: toLang.key,
-      // });
-
-      debug("prepareSetLocationUrl", newUrl);
-
       // register current langage (usefull only if we don't reload the app.)
       this.currentLang = toLang;
-
-      // // TODO remove
-      return;
       // reload application
-      this.reloadOrRefresh(newUrl, forcePageReload);
+      return this.reloadOrRefresh(newUrl, forcePageReload);
     }
 
     // if other, case default language need to be hidden from URL

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -56,7 +56,10 @@ export function getLangPathByPath(
   lang = LangService.currentLang?.key,
   routes = ROUTERS?.routes
 ): string {
-  if (!routes || !lang) return;
+  if (!routes || !lang) {
+    debug("No routes or no lang is set, return", { routes, lang });
+    return;
+  }
 
   // selected path depend of what we recieve
   const sPath = path?.[lang] || path;

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -4,7 +4,7 @@ import { ROUTERS } from "../api/routers";
 const debug = require("debug")("router:langHelpers");
 
 /**
- * Select current lang path by Lang
+ * Get current lang path by Lang
  *
  * ex:
  * const route = {
@@ -17,7 +17,7 @@ const debug = require("debug")("router:langHelpers");
  * @param route
  * @param lang
  */
-export function selectLangPathByLang(
+export function getLangPathByLang(
   route: TRoute,
   lang = LangService.currentLang?.key
 ): string {
@@ -33,35 +33,47 @@ export function selectLangPathByLang(
 }
 
 /**
- * Select lang path by another lang path
+ * Get lang path by another lang path
  * ex:
  *     path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" },
  *
  * with "/about", we need "fr" path  "/a-propos"
  * selectLangPathByPath("/about", "fr", routes) // will return "/a-propos"
  *
+ *
+ * ex 2
+ * Path can be an object with all available related lang path string too:
+ *
+ *  const pathsObj = path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" };
+ *  * selectLangPathByPath(pathsObj, "fr", routes) // will return "/a-propos"
+ *
  * @param path: current path
  * @param lang: Lang key we want to get the alternate path
  * @param routes: Route liste
  */
-export function selectLangPathByPath(
-  path: string,
+export function getLangPathByPath(
+  path: string | { [x: string]: string },
   lang = LangService.currentLang?.key,
   routes = ROUTERS?.routes
 ): string {
   if (!routes || !lang) return;
 
-  for (let route of routes) {
+  // selected path depend of what we recieve
+  const sPath = path?.[lang] || path;
+
+  for (let i in routes) {
+    const route = routes[i];
+
     // if route path is route.path, no alernate path, just return it.
     if (typeof route.path === "string") {
-      if (path === route.path) {
+      if (sPath === route.path) {
         return route.path;
       }
     }
     // if route path is an object with different paths by lang
     else if (typeof route.path === "object") {
       const matchingPathLang = Object.keys(route.path as { [x: string]: string }).find(
-        (langKey: string) => route.path?.[langKey] === path
+        (langKey: string) => route.path?.[langKey] === sPath
       );
       if (!matchingPathLang) continue;
       return route.path?.[lang];

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -1,5 +1,6 @@
 import { LangService, TRoute } from "..";
 import { ROUTERS } from "../api/routers";
+import { getUrlByPath, joinPaths } from "../api/helpers";
 
 const debug = require("debug")("router:langHelpers");
 
@@ -64,8 +65,10 @@ export function getLangPathByPath(
   // selected path depend of what we recieve
   const sPath = path?.[lang] || path;
 
-  for (let i in routes) {
-    const route = routes[i];
+  const localPath: string[] = [];
+
+  for (let route of routes) {
+    debug("route.path:", route.path);
 
     // if route path is route.path, no alernate path, just return it.
     if (typeof route.path === "string") {

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -1,9 +1,19 @@
 import { LangService, TRoute } from "..";
 import { ROUTERS } from "../api/routers";
+
 const debug = require("debug")("router:langHelpers");
 
 /**
  * Select current lang path by Lang
+ *
+ * ex:
+ * const route = {
+ *     component: ...,
+ *     path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" },
+ * }
+ *
+ * selectLangPathByLang(route, "fr") // will return  "/a-propos"
+ *
  * @param route
  * @param lang
  */
@@ -23,34 +33,38 @@ export function selectLangPathByLang(
 }
 
 /**
- * Select lang path by alternate path
+ * Select lang path by another lang path
+ * ex:
+ *     path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" },
+ *
+ * with "/about", we need "fr" path  "/a-propos"
+ * selectLangPathByPath("/about", "fr", routes) // will return "/a-propos"
+ *
  * @param path: current path
  * @param lang: Lang key we want to get the alternate path
  * @param routes: Route liste
  */
-export function selectLangAlternatePathByPath(
+export function selectLangPathByPath(
   path: string,
   lang = LangService.currentLang?.key,
   routes = ROUTERS?.routes
 ): string {
   if (!routes || !lang) return;
 
-  for (let i in routes) {
-    const route = routes[i];
+  for (let route of routes) {
     // if route path is route.path, no alernate path, just return it.
     if (typeof route.path === "string") {
-      if (path === route.path) return route.path;
+      if (path === route.path) {
+        return route.path;
+      }
     }
-
     // if route path is an object with different paths by lang
     else if (typeof route.path === "object") {
-      Object.keys(route.path as { [x: string]: string }).forEach((langKey: string) => {
-        if (route.path?.[langKey] === path) {
-          debug("param path", path);
-          debug("route.path?.[lang]", route.path?.[lang]);
-          return route.path?.[lang];
-        }
-      });
+      const matchingPathLang = Object.keys(route.path as { [x: string]: string }).find(
+        (langKey: string) => route.path?.[langKey] === path
+      );
+      if (!matchingPathLang) continue;
+      return route.path?.[lang];
     }
   }
 }

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -1,0 +1,56 @@
+import { LangService, TRoute } from "..";
+import { ROUTERS } from "../api/routers";
+const debug = require("debug")("router:langHelpers");
+
+/**
+ * Select current lang path by Lang
+ * @param route
+ * @param lang
+ */
+export function selectLangPathByLang(
+  route: TRoute,
+  lang = LangService.currentLang?.key
+): string {
+  let selectedPath: string;
+  if (typeof route.path === "string") {
+    selectedPath = route.path;
+  } else if (typeof route.path === "object") {
+    Object.keys(route.path).find((el) => {
+      if (el === lang) selectedPath = route.path?.[el];
+    });
+  }
+  return selectedPath;
+}
+
+/**
+ * Select lang path by alternate path
+ * @param path: current path
+ * @param lang: Lang key we want to get the alternate path
+ * @param routes: Route liste
+ */
+export function selectLangAlternatePathByPath(
+  path: string,
+  lang = LangService.currentLang?.key,
+  routes = ROUTERS?.routes
+): string {
+  if (!routes || !lang) return;
+
+  for (let i in routes) {
+    const route = routes[i];
+    // if route path is route.path, no alernate path, just return it.
+    if (typeof route.path === "string") {
+      if (path === route.path) return route.path;
+    }
+
+    // if route path is an object with different paths by lang
+    else if (typeof route.path === "object") {
+      Object.keys(route.path as { [x: string]: string }).forEach((langKey: string) => {
+        if (route.path?.[langKey] === path) {
+          debug("param path", path);
+          debug("route.path?.[lang]", route.path?.[lang]);
+          return route.path?.[lang];
+        }
+      });
+    }
+  }
+}

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -45,7 +45,7 @@ export function getLangPathByLang(
  * ex 2
  * Path can be an object with all available related lang path string too:
  *
- *  const pathsObj = path: { en: "/about", fr: "/a-propos", de: "uber" };
+ *  const pathsObj = path: { en: "/about", fr: "/a-propos", de: "/uber" };
  *  * selectLangPathByPath(pathsObj, "fr", routes) // will return "/a-propos"
  *
  * @param path: current path

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -1,6 +1,6 @@
 import { LangService, TRoute } from "..";
 import { ROUTERS } from "../api/routers";
-import { extractPathFromBase, getUrlByPath, joinPaths } from "../api/helpers";
+import { removeBaseToUrl, joinPaths } from "../api/helpers";
 
 const debug = require("debug")("router:langHelpers");
 
@@ -36,7 +36,7 @@ export function getLangPathByLang(
 /**
  * Get lang path by another lang path
  * ex:
- *     path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" },
+ *     path: { en: "/about", fr: "/a-propos", de: "uber" },
  *
  * with "/about", we need "fr" path  "/a-propos"
  * selectLangPathByPath("/about", "fr", routes) // will return "/a-propos"
@@ -45,7 +45,7 @@ export function getLangPathByLang(
  * ex 2
  * Path can be an object with all available related lang path string too:
  *
- *  const pathsObj = path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" };
+ *  const pathsObj = path: { en: "/about", fr: "/a-propos", de: "uber" };
  *  * selectLangPathByPath(pathsObj, "fr", routes) // will return "/a-propos"
  *
  * @param path: current path
@@ -82,7 +82,7 @@ export function getLangPathByPath({
   // quick fix in case base is a simple "/"
   if (base === "/") base = "";
   // path without base
-  const pathWithoutBase = extractPathFromBase(initialPath, base);
+  const pathWithoutBase = removeBaseToUrl(initialPath, base);
 
   for (let route of routes) {
     log && debug("> route", route);
@@ -100,7 +100,7 @@ export function getLangPathByPath({
     if (routePath === pathWithoutBase || pathWithoutBaseMatchWithOnePathLang) {
       // pousser dans la tableau
       storePaths.push(routePath);
-      log && debug("> !!!!!!!! FINAL return: ", joinPaths(storePaths));
+      log && debug("> FINAL return: ", joinPaths(storePaths));
       // retourner le path final
       return joinPaths(storePaths);
     }

--- a/src/lang/langHelpers.ts
+++ b/src/lang/langHelpers.ts
@@ -46,9 +46,10 @@ export function getLangPathByLang(
  * Path can be an object with all available related lang path string too:
  *
  *  const pathsObj = path: { en: "/about", fr: "/a-propos", de: "/uber" };
+ *  So, with pathObj, we need fr path "/a-propos"
  *  * selectLangPathByPath(pathsObj, "fr", routes) // will return "/a-propos"
  *
- * @param path: current path
+ * @param path: current path string or object
  * @param base
  * @param lang: Lang key we want to get the alternate path
  * @param routes: Route liste

--- a/test/CreateRouter.test.ts
+++ b/test/CreateRouter.test.ts
@@ -43,7 +43,7 @@ describe("CreateRouter", () => {
     expect(getRoute.fullUrl).toBe(`${base}/bar/foo`);
     expect(getRoute.fullPath).toBe(`${base}/bar/:id`);
     expect(getRoute.path).toBe("/bar/:id");
-    expect(getRoute.matchUrl).toBe("/bar/foo");
+    expect(getRoute.url).toBe("/bar/foo");
     expect(getRoute.name).toBe(`BarPage`);
     expect(getRoute.props).toEqual({ params: { id: "foo" }, color: "blue" });
   });

--- a/test/CreateRouter.test.ts
+++ b/test/CreateRouter.test.ts
@@ -1,5 +1,4 @@
-import React from "react";
-import { CreateRouter, ERouterEvent, TRoute } from "../src";
+import { CreateRouter, TRoute } from "../src";
 import { ROUTERS } from "../src/api/routers";
 import { preventSlashes } from "../src/api/helpers";
 

--- a/test/LangService.test.tsx
+++ b/test/LangService.test.tsx
@@ -4,8 +4,8 @@ import React from "react";
 
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 const routesList: TRoute[] = [
-  { path: "/", component: null },
-  { path: "/foo", component: null },
+  { path: "/", name: "home" },
+  { path: "/foo", name: "foo" },
 ];
 
 const mockClickHandler = jest.fn();
@@ -22,27 +22,6 @@ const App = ({ base = "/", to = "/foo" }) => {
   );
 };
 
-const setUrl = (url) => {
-  const parser = document.createElement("a");
-  parser.href = url;
-  [
-    "href",
-    "protocol",
-    "host",
-    "hostname",
-    "origin",
-    "port",
-    "pathname",
-    "search",
-    "hash",
-  ].forEach((prop) => {
-    Object.defineProperty(window.location, prop, {
-      value: parser[prop],
-      writable: true,
-    });
-  });
-};
-
 const windowOpenMock = jest.fn();
 
 beforeAll(() => {
@@ -57,7 +36,7 @@ afterEach(() => {
 });
 
 describe("LangService", () => {
-  it("should turn init to true after init", () => {
+  it("should turn isInit property to true after init", () => {
     LangService.init(locales);
     expect(LangService.isInit).toBe(true);
   });
@@ -66,7 +45,7 @@ describe("LangService", () => {
    * setLang
    */
   it("should set lang properly", () => {
-    LangService.init(locales, true);
+    LangService.init(locales, false);
     render(<App />);
     act(() => LangService.setLang(locales[1]));
     expect(window.open).toHaveBeenCalledWith(`/${locales[1].key}`, "_self");

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -70,7 +70,7 @@ describe("getUrlByPath", () => {
             path: "/foo",
             component: null,
             children: [
-              { path: "/zoo", component: null },
+              { path: "/:zoo", component: null },
               { path: "/bla", component: null },
             ],
           },
@@ -78,7 +78,7 @@ describe("getUrlByPath", () => {
       },
     ];
     expect(getUrlByPath(routesList, "/foo")).toBe("/hello/foo");
-    expect(getUrlByPath(routesList, "/zoo")).toBe("/hello/foo/zoo");
+    expect(getUrlByPath(routesList, "/zoo")).toBe("/hello/foo/:zoo");
   });
 });
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   preventSlashes,
   removeLastCharFromString,
 } from "../src/api/helpers";
+import { LangService } from "../src";
 
 describe("removeLastCharFromString", () => {
   it("should not remove last character if string === lastChar", () => {
@@ -60,39 +61,51 @@ describe("buildUrl", () => {
 describe("getUrlByPath", () => {
   it("should return full URL", () => {
     const routesList = [
-      { path: "/", component: null },
+      { path: "/" },
       {
         path: "/hello",
-        component: null,
         children: [
-          { path: "/bar", component: null },
+          { path: "/bar" },
           {
             path: "/foo",
-            component: null,
-            children: [
-              { path: "/:zoo", component: null },
-              { path: "/bla", component: null },
-            ],
+            children: [{ path: "/:zoo" }, { path: "/bla" }],
           },
         ],
       },
     ];
     expect(getUrlByPath(routesList, "/foo")).toBe("/hello/foo");
-    expect(getUrlByPath(routesList, "/zoo")).toBe("/hello/foo/:zoo");
+    expect(getUrlByPath(routesList, "/:zoo")).toBe("/hello/foo/:zoo");
+  });
+
+  it("sound return full URL ", () => {
+    LangService.init([{ key: "fr" }, { key: "en" }], true);
+    const routesListLang = [
+      {
+        path: { fr: "/salut", en: "/hello" },
+        children: [
+          {
+            path: { en: "/bar-en", fr: "/bar-fr" },
+            children: [{ path: { en: "/foo-en", fr: "/foo-fr" } }, { path: "/foo" }],
+          },
+          { path: "/foo" },
+        ],
+      },
+    ];
+
+    expect(getUrlByPath(routesListLang, "/foo-fr")).toBe("/salut/bar-fr/foo-fr");
   });
 });
 
 describe("getUrlByRouteName", () => {
   it("should return full URL with only page name and params", () => {
     const routesList = [
-      { path: "/", component: null, name: "foo" },
+      { path: "/", name: "foo" },
       {
         path: "/hello",
-        component: null,
         name: "bar",
         children: [
-          { path: "/zoo", component: null, name: "ZooPage" },
-          { path: "/:id", component: null, name: "BlaPage" },
+          { path: "/zoo", name: "ZooPage" },
+          { path: "/:id", name: "BlaPage" },
         ],
       },
     ];

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -77,15 +77,25 @@ describe("getUrlByPath", () => {
     expect(getUrlByPathPart(routesList, "/:zoo")).toBe("/hello/foo/:zoo");
   });
 
-  it("sound return full URL ", () => {
+  it("should return full URL ", () => {
     LangService.init([{ key: "fr" }, { key: "en" }], true);
     const routesListLang = [
       {
-        path: { fr: "/salut", en: "/hello" },
+        path: "/hello",
+        langPath: { fr: "/salut", en: "/hello" },
         children: [
           {
-            path: { en: "/bar-en", fr: "/bar-fr" },
-            children: [{ path: { en: "/foo-en", fr: "/foo-fr" } }, { path: "/foo" }],
+            path: "/bar-en",
+            langPath: { en: "/bar-en", fr: "/bar-fr" },
+            children: [
+              {
+                path: "/foo-en",
+                langPath: { en: "/foo-en", fr: "/foo-fr" },
+              },
+              {
+                path: "/zoo",
+              },
+            ],
           },
           { path: "/foo" },
         ],

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,6 @@
 import {
   buildUrl,
-  getUrlByPath,
+  getUrlByPathPart,
   getUrlByRouteName,
   joinPaths,
   preventSlashes,
@@ -73,8 +73,8 @@ describe("getUrlByPath", () => {
         ],
       },
     ];
-    expect(getUrlByPath(routesList, "/foo")).toBe("/hello/foo");
-    expect(getUrlByPath(routesList, "/:zoo")).toBe("/hello/foo/:zoo");
+    expect(getUrlByPathPart(routesList, "/foo")).toBe("/hello/foo");
+    expect(getUrlByPathPart(routesList, "/:zoo")).toBe("/hello/foo/:zoo");
   });
 
   it("sound return full URL ", () => {
@@ -92,7 +92,7 @@ describe("getUrlByPath", () => {
       },
     ];
 
-    expect(getUrlByPath(routesListLang, "/foo-fr")).toBe("/salut/bar-fr/foo-fr");
+    expect(getUrlByPathPart(routesListLang, "/foo-fr")).toBe("/salut/bar-fr/foo-fr");
   });
 });
 

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -4,72 +4,103 @@ import { getLangPathByPath } from "../src/lang/langHelpers";
 export const routesList: TRoute[] = [
   {
     path: { en: "/home", fr: "/accueil", de: "/zuhause" },
-    component: null,
     name: "home",
   },
-  { path: "/news", component: null, name: "news" },
+  { path: "/news", name: "news" },
   {
     path: { en: "/about", fr: "/a-propos", de: "uber" },
-    //path: { en: "/about", fr: "/a-propos", de: "uber" },
     name: "about",
-    component: null,
+
     children: [
       {
-        //path: "/foo-en",
         path: { en: "/foo-en", fr: "/foo-fr", de: "foo-de" },
         name: "foo",
-        component: null,
       },
-      { path: "/bar", component: null, name: "bar" },
+      { path: "/bar", name: "bar" },
     ],
   },
 ];
 
 describe("langHelpers", () => {
-  // // FIXME REMOVE ONLY
-  // it("getLangPathByPath: get path router + subrouter string as param, should return path properly", () => {
-  //   const alternatePath = getLangPathByPath({
-  //     path: "/foo-fr",
-  //     base: "/a-propos",
-  //     lang: "en",
-  //     routes: routesList
-  //   });
-  //   expect(alternatePath).toBe("/about/foo-en");
-  // });
+  it("getLangPathByPath: get path router + subrouter string as param, should return path properly", () => {
+    const routes = [
+      {
+        path: "/home",
+        children: [{ path: "/zoo" }],
+      },
+      {
+        path: "/foo/bar",
+        children: [{ path: "/foo2" }],
+      },
+      {
+        path: "/ok/bar",
+        children: [{ path: "/foo2" }],
+      },
+    ];
+    //prettier-ignore
+    expect(getLangPathByPath({ path: "/home", lang: "fr", routes }))
+      .toBe("/home");
+    // prettier-ignore
+    expect(getLangPathByPath({ path: "/home/zoo", base: "/home", routes }))
+      .toBe("/home/zoo");
+    //prettier-ignore
+    expect(getLangPathByPath({ path: "/ok/bar/foo2", base: "/ok/bar", routes }))
+      .toBe("/ok/bar/foo2");
+  });
+
+  it("getLangPathByPath: get path router + subrouter object as param, should return path properly", () => {
+    const routes = [
+      {
+        path: { en: "/home", fr: "/accueil", de: "/zuhause" },
+        children: [
+          {
+            path: { en: "/foo-en", fr: "/foo-fr", de: "/foo-de" },
+          },
+        ],
+      },
+    ];
+    // prettier-ignore
+    expect(getLangPathByPath({ path: "/accueil/foo-fr", base: "/accueil", lang: "en", routes }))
+      .toBe("/home/foo-en");
+    // prettier-ignore
+    expect(getLangPathByPath({ path: "/zuhause/foo-de", base: "/zuhause", lang: "en", routes }))
+      .toBe("/home/foo-en");
+  });
 
   it("getLangPathByPath: should return path if current path is string", () => {
     const testRoute = routesList.find((el) => el.name === "news");
     const path = testRoute.path;
-    const alternatePath = getLangPathByPath({
-      path: path,
-      base: "/",
-      lang: "de",
-      routes: routesList
-    });
-    expect(alternatePath).toBe(testRoute.path);
+    expect(
+      getLangPathByPath({
+        path: path,
+        lang: "de",
+        routes: routesList,
+      })
+    ).toBe(path);
   });
 
   it("getLangPathByPath: get path string as param, should return path properly", () => {
     const testRoute = routesList.find((el) => el.name === "home");
-    const path: string = testRoute.path;
-    const alternatePath = getLangPathByPath({
-      path: path,
-      base: "/",
-      lang: "de",
-      routes: routesList
-    });
-    expect(alternatePath).toBe(testRoute?.path?.de);
+    expect(
+      getLangPathByPath({
+        path: testRoute.path,
+        base: "/",
+        lang: "de",
+        routes: routesList,
+      })
+    ).toBe(testRoute?.path?.de);
   });
 
   it("getLangPathByPath: get path object as param, should return path properly", () => {
     const testRoute = routesList.find((el) => el.name === "home");
-    const path: { [x: string]: string } = testRoute.path;
-    const alternatePath = getLangPathByPath({
-      path: path,
-      base: "/",
-      lang: "de",
-      routes: routesList
-    });
-    expect(alternatePath).toBe(testRoute?.path?.de);
+    const path = testRoute?.path;
+    expect(
+      getLangPathByPath({
+        path: path,
+        base: "/",
+        lang: "de",
+        routes: routesList,
+      })
+    ).toBe(path?.de);
   });
 });

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,5 +1,5 @@
 import { TRoute } from "../src";
-import { selectLangPathByPath } from "../src/lang/langHelpers";
+import { getLangPathByPath } from "../src/lang/langHelpers";
 
 export const routesList: TRoute[] = [
   {
@@ -19,19 +19,24 @@ export const routesList: TRoute[] = [
 ];
 
 describe("langHelpers", () => {
-  it("selectAlternateLangPathByPath: sould return path if current path is string", () => {
+  it("getLangPathByPath: should return path if current path is string", () => {
     const testRoute = routesList.find((el) => el.name === "news");
-    const alternatePath = selectLangPathByPath(testRoute.path, "de", routesList);
+    const path = testRoute.path;
+    const alternatePath = getLangPathByPath(path, "de", routesList);
     expect(alternatePath).toBe(testRoute.path);
   });
 
-  it("selectAlternateLangPathByPath: sould return path if current path is object", () => {
+  it("getLangPathByPath: get path string as param, should return path properly", () => {
     const testRoute = routesList.find((el) => el.name === "home");
-    const alternatePath = selectLangPathByPath(
-      testRoute.path.fr,
-      "de",
-      routesList
-    );
+    const path: string = testRoute.path;
+    const alternatePath = getLangPathByPath(path, "de", routesList);
+    expect(alternatePath).toBe(testRoute?.path?.de);
+  });
+
+  it("getLangPathByPath: get path object as param, should return path properly", () => {
+    const testRoute = routesList.find((el) => el.name === "home");
+    const path: { [x: string]: string } = testRoute.path;
+    const alternatePath = getLangPathByPath(path, "de", routesList);
     expect(alternatePath).toBe(testRoute?.path?.de);
   });
 });

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -26,18 +26,18 @@ export const routesList: TRoute[] = [
 ];
 
 describe("langHelpers", () => {
-  // FIXME REMOVE ONLY
-  it("getLangPathByPath: get path router + subrouter string as param, should return path properly", () => {
-    const alternatePath = getLangPathByPath({
-      path: "/foo-fr",
-      base: "/a-propos",
-      lang: "en",
-      routes: routesList
-    });
-    expect(alternatePath).toBe("/about/foo-en");
-  });
+  // // FIXME REMOVE ONLY
+  // it("getLangPathByPath: get path router + subrouter string as param, should return path properly", () => {
+  //   const alternatePath = getLangPathByPath({
+  //     path: "/foo-fr",
+  //     base: "/a-propos",
+  //     lang: "en",
+  //     routes: routesList
+  //   });
+  //   expect(alternatePath).toBe("/about/foo-en");
+  // });
 
-  it.only("getLangPathByPath: should return path if current path is string", () => {
+  it("getLangPathByPath: should return path if current path is string", () => {
     const testRoute = routesList.find((el) => el.name === "news");
     const path = testRoute.path;
     const alternatePath = getLangPathByPath({

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,4 +1,5 @@
 import { TRoute } from "../src";
+import { getLangPathByPath } from "../src/lang/langHelpers";
 //import { getLangPathByPath } from "../src/lang/langHelpers";
 
 export const routesList: TRoute[] = [

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,0 +1,30 @@
+import { TRoute } from "../src";
+import { selectLangAlternatePathByPath } from "../src/lang/langHelpers";
+
+export const routesList: TRoute[] = [
+  { path: { en: "/home", fr: "/accueil" }, component: null },
+  { path: "/news", component: null },
+  {
+    path: { en: "/about", fr: "/a-propos" },
+    component: null,
+    children: [
+      { path: "/foo", component: null },
+      { path: "/bar", component: null },
+    ],
+  },
+];
+
+describe("langHelpers", () => {
+  it("selectLangPathByAlternatePath: sould return path if current path is string", () => {
+    const alternatePath = selectLangAlternatePathByPath("/news", "en", routesList);
+    const testRoute = routesList.find((el) => el.path === "/news");
+    console.log("testRoute", testRoute);
+    expect(alternatePath).toBe(testRoute.path);
+  });
+
+  it("selectLangPathByAlternatePath: sould return path if current path is object", () => {
+    const alternatePath = selectLangAlternatePathByPath("/a-propos", "en", routesList);
+    const testRoute = routesList.find((el) => el.path?.fr === "/a-propos");
+    expect(alternatePath).toBe(testRoute.path?.en);
+  });
+});

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,30 +1,37 @@
 import { TRoute } from "../src";
-import { selectLangAlternatePathByPath } from "../src/lang/langHelpers";
+import { selectLangPathByPath } from "../src/lang/langHelpers";
 
 export const routesList: TRoute[] = [
-  { path: { en: "/home", fr: "/accueil" }, component: null },
-  { path: "/news", component: null },
   {
-    path: { en: "/about", fr: "/a-propos" },
+    path: { en: "/home", fr: "/accueil", de: "/zuhause" },
+    component: null,
+    name: "home",
+  },
+  { path: "/news", component: null, name: "news" },
+  {
+    path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" },
     component: null,
     children: [
-      { path: "/foo", component: null },
-      { path: "/bar", component: null },
+      { path: "/foo", component: null, name: "foo" },
+      { path: "/bar", component: null, name: "bar" },
     ],
   },
 ];
 
 describe("langHelpers", () => {
-  it("selectLangPathByAlternatePath: sould return path if current path is string", () => {
-    const alternatePath = selectLangAlternatePathByPath("/news", "en", routesList);
-    const testRoute = routesList.find((el) => el.path === "/news");
-    console.log("testRoute", testRoute);
+  it("selectAlternateLangPathByPath: sould return path if current path is string", () => {
+    const testRoute = routesList.find((el) => el.name === "news");
+    const alternatePath = selectLangPathByPath(testRoute.path, "de", routesList);
     expect(alternatePath).toBe(testRoute.path);
   });
 
-  it("selectLangPathByAlternatePath: sould return path if current path is object", () => {
-    const alternatePath = selectLangAlternatePathByPath("/a-propos", "en", routesList);
-    const testRoute = routesList.find((el) => el.path?.fr === "/a-propos");
-    expect(alternatePath).toBe(testRoute.path?.en);
+  it("selectAlternateLangPathByPath: sould return path if current path is object", () => {
+    const testRoute = routesList.find((el) => el.name === "home");
+    const alternatePath = selectLangPathByPath(
+      testRoute.path.fr,
+      "de",
+      routesList
+    );
+    expect(alternatePath).toBe(testRoute?.path?.de);
   });
 });

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,5 +1,5 @@
 import { TRoute } from "../src";
-import { getLangPathByPath } from "../src/lang/langHelpers";
+//import { getLangPathByPath } from "../src/lang/langHelpers";
 
 export const routesList: TRoute[] = [
   {
@@ -54,13 +54,14 @@ describe("langHelpers", () => {
         path: { en: "/home", fr: "/accueil", de: "/zuhause" },
         children: [
           {
-            path: { en: "/foo-en", fr: "/foo-fr", de: "/foo-de" },
+            path: { en: "/foo-en", fr: "/:id", de: "/foo-de" },
           },
         ],
       },
     ];
     // prettier-ignore
     expect(getLangPathByPath({ path: "/accueil/foo-fr", base: "/accueil", lang: "en", routes }))
+//    /accueil/:id/
       .toBe("/home/foo-en");
     // prettier-ignore
     expect(getLangPathByPath({ path: "/zuhause/foo-de", base: "/zuhause", lang: "en", routes }))

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -9,34 +9,67 @@ export const routesList: TRoute[] = [
   },
   { path: "/news", component: null, name: "news" },
   {
-    path: { en: "/about", fr: "/a-propos", de: "uber", name: "about" },
+    path: { en: "/about", fr: "/a-propos", de: "uber" },
+    //path: { en: "/about", fr: "/a-propos", de: "uber" },
+    name: "about",
     component: null,
     children: [
-      { path: "/foo", component: null, name: "foo" },
+      {
+        //path: "/foo-en",
+        path: { en: "/foo-en", fr: "/foo-fr", de: "foo-de" },
+        name: "foo",
+        component: null,
+      },
       { path: "/bar", component: null, name: "bar" },
     ],
   },
 ];
 
 describe("langHelpers", () => {
-  it("getLangPathByPath: should return path if current path is string", () => {
+  // FIXME REMOVE ONLY
+  it("getLangPathByPath: get path router + subrouter string as param, should return path properly", () => {
+    const alternatePath = getLangPathByPath({
+      path: "/foo-fr",
+      base: "/a-propos",
+      lang: "en",
+      routes: routesList
+    });
+    expect(alternatePath).toBe("/about/foo-en");
+  });
+
+  it.only("getLangPathByPath: should return path if current path is string", () => {
     const testRoute = routesList.find((el) => el.name === "news");
     const path = testRoute.path;
-    const alternatePath = getLangPathByPath(path, "de", routesList);
+    const alternatePath = getLangPathByPath({
+      path: path,
+      base: "/",
+      lang: "de",
+      routes: routesList
+    });
     expect(alternatePath).toBe(testRoute.path);
   });
 
   it("getLangPathByPath: get path string as param, should return path properly", () => {
     const testRoute = routesList.find((el) => el.name === "home");
     const path: string = testRoute.path;
-    const alternatePath = getLangPathByPath(path, "de", routesList);
+    const alternatePath = getLangPathByPath({
+      path: path,
+      base: "/",
+      lang: "de",
+      routes: routesList
+    });
     expect(alternatePath).toBe(testRoute?.path?.de);
   });
 
   it("getLangPathByPath: get path object as param, should return path properly", () => {
     const testRoute = routesList.find((el) => el.name === "home");
     const path: { [x: string]: string } = testRoute.path;
-    const alternatePath = getLangPathByPath(path, "de", routesList);
+    const alternatePath = getLangPathByPath({
+      path: path,
+      base: "/",
+      lang: "de",
+      routes: routesList
+    });
     expect(alternatePath).toBe(testRoute?.path?.de);
   });
 });

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,5 +1,6 @@
 import { TRoute } from "../src";
 import { getLangPathByPath } from "../src/lang/langHelpers";
+import { TPathLangObject } from "../src/api/CreateRouter";
 
 export const routesList: TRoute[] = [
   {
@@ -88,12 +89,12 @@ describe("langHelpers", () => {
         lang: "de",
         routes: routesList,
       })
-    ).toBe(testRoute?.path?.de);
+    ).toBe((testRoute?.path as TPathLangObject)?.de);
   });
 
   it("getLangPathByPath: get path object as param, should return path properly", () => {
     const testRoute = routesList.find((el) => el.name === "home");
-    const path = testRoute?.path;
+    const path = testRoute?.path as TPathLangObject;
     expect(
       getLangPathByPath({
         path: path,

--- a/test/langHelpers.test.ts
+++ b/test/langHelpers.test.ts
@@ -1,6 +1,5 @@
 import { TRoute } from "../src";
 import { getLangPathByPath } from "../src/lang/langHelpers";
-//import { getLangPathByPath } from "../src/lang/langHelpers";
 
 export const routesList: TRoute[] = [
   {
@@ -11,7 +10,6 @@ export const routesList: TRoute[] = [
   {
     path: { en: "/about", fr: "/a-propos", de: "uber" },
     name: "about",
-
     children: [
       {
         path: { en: "/foo-en", fr: "/foo-fr", de: "foo-de" },
@@ -55,7 +53,7 @@ describe("langHelpers", () => {
         path: { en: "/home", fr: "/accueil", de: "/zuhause" },
         children: [
           {
-            path: { en: "/foo-en", fr: "/:id", de: "/foo-de" },
+            path: { en: "/foo-en", fr: "/foo-fr", de: "/foo-de" },
           },
         ],
       },

--- a/test/langMiddleware.test.ts
+++ b/test/langMiddleware.test.ts
@@ -1,40 +1,47 @@
-import { langMiddleware, TRoute } from "../src";
+import { langMiddleware, LangService, TRoute } from "../src";
 
-const routesList: TRoute[] = [
+/**
+ * Add lang path param allows to test the same array before and after middleware
+ * The middleware added langPath param even if it doesn't patch all routes
+ * @param addLangPath
+ */
+const routesList = (addLangPath = false): TRoute[] => [
   {
     path: "/",
-    component: null,
+    ...(addLangPath ? { langPath: null } : {}),
   },
   {
     path: "/hello",
-    component: null,
+    ...(addLangPath ? { langPath: null } : {}),
     children: [
-      { path: "/zoo", component: null },
-      { path: "/:id", component: null },
+      { path: "/zoo", ...(addLangPath ? { langPath: null } : {}) },
+      { path: "/:id", ...(addLangPath ? { langPath: null } : {}) },
     ],
   },
 ];
 
 const patchRoutesList: TRoute[] = [
   {
-    path: "/:lang",
-    component: null,
+    path: "/:lang/",
+    langPath: null,
   },
   {
     path: "/:lang/hello",
-    component: null,
+    langPath: null,
     children: [
-      { path: "/zoo", component: null },
-      { path: "/:id", component: null },
+      { path: "/zoo", langPath: null },
+      { path: "/:id", langPath: null },
     ],
   },
 ];
 
 describe("LangMiddleware", () => {
+  LangService.init([{ key: "fr" }, { key: "en" }], true);
   it("should patch all first level routes if LangService is init", () => {
-    expect(langMiddleware(routesList, true)).toEqual(patchRoutesList);
+    expect(langMiddleware(routesList(), true)).toEqual(patchRoutesList);
   });
+
   it("should not patch routes if LangService is not init", () => {
-    expect(langMiddleware(routesList, false)).toEqual(routesList);
+    expect(langMiddleware(routesList(), false)).toEqual(routesList(true));
   });
 });


### PR DESCRIPTION
fix #44 

- [x] path object can accept string path AND lang path object 

```js
// string
path : "/foo"
// object
path { fr:"foo-fr", de:"foo-de", en:"foo-en" }
```

`TRoute` takes `langPath` property used by `langMiddleware` to store path lang object if exist ; Because we always need to know the alternates lang path. ex: if y need to switch to lang "de" -> I need to know what is "de" path


- [x] adapt tests
- [x] documentation