### PR TITLE
Change history props API

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ $ npm run dev
 Router component creates a new router instance.
 
 ```jsx
-<Router routes={} base={} historyMode={} middlewares={}>
+<Router routes={} base={} history={} middlewares={}>
   {/* can now use <Link /> and <Stack /> component */}
 </Router>
 ```
@@ -374,8 +374,8 @@ Router component creates a new router instance.
 
 - **routes** `TRoute[]` Routes list
 - **base** `string` Base URL - default: `"/"``
-- **historyMode** `EHistoryMode` _(optional)_ choose history mode. -
-  default : `EHistoryMode.BROWSER`
+- **history** `BrowserHistory | HashHistory | MemoryHistory` _(optional)_ create and set an history () -
+  default : `BrowserHistory`
   History mode can
   be [BROWSER](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md#createbrowserhistory)
   ,

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ npm i @cher-ami/router -s
 ```jsx
 import React from "react";
 import { Router, Link, Stack } from "@cher-ami/router";
+import { createBrowserHistory } from "history";
 
 const routesList = [
   {
@@ -89,9 +90,11 @@ const routesList = [
   },
 ];
 
+const history = createBrowserHistory();
+
 function App() {
   return (
-    <Router routes={routesList} base={"/"}>
+    <Router routes={routesList} history={history} base={"/"}>
       <nav>
         <Link to={"/"} />
         <Link to={"/foo"} />
@@ -373,8 +376,8 @@ Router component creates a new router instance.
 **Props:**
 
 - **routes** `TRoute[]` Routes list
-- **base** `string` Base URL - default: `"/"``
-- **history** `BrowserHistory | HashHistory | MemoryHistory` create and set an history () -
+- **base** `string` Base URL - default: `"/"`
+- **history** `BrowserHistory | HashHistory | MemoryHistory` _(optional)_ create and set an history () -
   default : `BrowserHistory`
   History mode can
   be [BROWSER](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md#createbrowserhistory)

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Router component creates a new router instance.
 
 - **routes** `TRoute[]` Routes list
 - **base** `string` Base URL - default: `"/"``
-- **history** `BrowserHistory | HashHistory | MemoryHistory` _(optional)_ create and set an history () -
+- **history** `BrowserHistory | HashHistory | MemoryHistory` create and set an history () -
   default : `BrowserHistory`
   History mode can
   be [BROWSER](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md#createbrowserhistory)

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -11,7 +11,7 @@ import ArticlePage from "./pages/ArticlePage";
 import FooPage from "./pages/FooPage";
 import BarPage from "./pages/BarPage";
 import "./index.css";
-import { createBrowserHistory } from "history";
+import { createBrowserHistory, createMemoryHistory } from "history";
 
 const debug = require("debug")(`router:index`);
 
@@ -58,18 +58,11 @@ const baseUrl = "/custom-base";
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 LangService.init(locales, true, baseUrl);
 
-const history = createBrowserHistory();
-
 /**
  * Init Application
  */
 ReactDOM.render(
-  <Router
-    routes={routesList}
-    base={baseUrl}
-    middlewares={[langMiddleware]}
-    history={history}
-  >
+  <Router routes={routesList} base={baseUrl} middlewares={[langMiddleware]}>
     <App />
   </Router>,
   document.getElementById("root")

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,7 +1,7 @@
 import ReactDOM from "react-dom";
 import * as React from "react";
 import { forwardRef } from "react";
-import { EHistoryMode, Router, TRoute } from "../src";
+import { Router, TRoute } from "../src";
 import { LangService, langMiddleware } from "../src";
 
 import App from "./App";
@@ -11,6 +11,7 @@ import ArticlePage from "./pages/ArticlePage";
 import FooPage from "./pages/FooPage";
 import BarPage from "./pages/BarPage";
 import "./index.css";
+import { createBrowserHistory, createMemoryHistory } from "history";
 
 const debug = require("debug")(`router:index`);
 
@@ -20,7 +21,7 @@ const debug = require("debug")(`router:index`);
 export const routesList: TRoute[] = [
   {
     path: "/",
-    //path: { en: "/", fr: "/", de: "/" },
+    // path: { en: "/", fr: "/", de: "/" },
     component: HomePage,
   },
   {
@@ -65,7 +66,7 @@ ReactDOM.render(
     routes={routesList}
     base={baseUrl}
     middlewares={[langMiddleware]}
-    historyMode={EHistoryMode.BROWSER}
+    history={createMemoryHistory()}
   >
     <App />
   </Router>,

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -11,7 +11,7 @@ import ArticlePage from "./pages/ArticlePage";
 import FooPage from "./pages/FooPage";
 import BarPage from "./pages/BarPage";
 import "./index.css";
-import { createBrowserHistory, createMemoryHistory } from "history";
+import { createBrowserHistory } from "history";
 
 const debug = require("debug")(`router:index`);
 
@@ -21,7 +21,7 @@ const debug = require("debug")(`router:index`);
 export const routesList: TRoute[] = [
   {
     path: "/",
-    // path: { en: "/", fr: "/", de: "/" },
+    //path: { en: "/", fr: "/", de: "/" },
     component: HomePage,
   },
   {
@@ -56,7 +56,9 @@ export const routesList: TRoute[] = [
 
 const baseUrl = "/custom-base";
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
-LangService.init(locales, false, baseUrl);
+LangService.init(locales, true, baseUrl);
+
+const history = createBrowserHistory();
 
 /**
  * Init Application
@@ -66,7 +68,7 @@ ReactDOM.render(
     routes={routesList}
     base={baseUrl}
     middlewares={[langMiddleware]}
-    history={createMemoryHistory()}
+    history={history}
   >
     <App />
   </Router>,

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -11,7 +11,6 @@ import ArticlePage from "./pages/ArticlePage";
 import FooPage from "./pages/FooPage";
 import BarPage from "./pages/BarPage";
 import "./index.css";
-import { createBrowserHistory, createMemoryHistory } from "history";
 
 const debug = require("debug")(`router:index`);
 

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -7,7 +7,7 @@ import {
   BrowserHistory,
   createBrowserHistory,
   HashHistory,
-  MemoryHistory
+  MemoryHistory,
 } from "history";
 
 const debug = require("debug")("router:CreateRouter");

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -4,12 +4,10 @@ import { EventEmitter } from "events";
 import { buildUrl, joinPaths } from "./helpers";
 import { ROUTERS } from "./routers";
 import {
-  createBrowserHistory,
-  createHashHistory,
-  createMemoryHistory,
   BrowserHistory,
+  createBrowserHistory,
   HashHistory,
-  MemoryHistory,
+  MemoryHistory
 } from "history";
 
 const debug = require("debug")("router:CreateRouter");
@@ -39,12 +37,6 @@ export type TRoute = {
   langPath?: { [x: string]: string } | null;
 };
 
-export enum EHistoryMode {
-  BROWSER = "browser",
-  HASH = "hash",
-  MEMORY = "memory",
-}
-
 export enum ERouterEvent {
   PREVIOUS_ROUTE_CHANGE = "previous-route-change",
   CURRENT_ROUTE_CHANGE = "current-route-change",
@@ -69,7 +61,7 @@ export class CreateRouter {
   public currentRoute: TRoute;
   public previousRoute: TRoute;
   // history mode choice used by history library›
-  public historyMode: EHistoryMode;
+  public history: BrowserHistory | HashHistory | MemoryHistory;
   // store history listener
   protected unlistenHistory;
   // router instance ID, useful for debug if there is multiple router instance
@@ -80,18 +72,18 @@ export class CreateRouter {
     middlewares,
     base = "/",
     id = 1,
-    historyMode = EHistoryMode.BROWSER,
+    history = createBrowserHistory(),
   }: {
     base?: string;
     routes: TRoute[];
     middlewares?: any[];
     id?: number | string;
-    historyMode?: EHistoryMode;
+    history?: BrowserHistory | HashHistory | MemoryHistory;
   }) {
     this.base = base;
     this.id = id;
     this.middlewares = middlewares;
-    this.historyMode = historyMode;
+    this.history = history;
 
     if (!routes) {
       throw new Error(`Router id ${id} > no routes array is set.`);
@@ -99,7 +91,7 @@ export class CreateRouter {
 
     if (!ROUTERS.history) {
       // create new history
-      ROUTERS.history = this.getHistory(this.historyMode);
+      ROUTERS.history = this.history;
       // push first location history object in global locationsHistory
       ROUTERS.locationsHistory.push(ROUTERS.history.location);
     }
@@ -152,25 +144,6 @@ export class CreateRouter {
   public destroyEvents(): void {
     // To stop listening, call the function returned from listen().
     this.unlistenHistory();
-  }
-
-  /**
-   * Select History mode
-   * doc: https://github.com/ReactTraining/history/blob/master/docs/getting-started.md
-   * @param historyMode
-   */
-  protected getHistory(
-    historyMode: EHistoryMode
-  ): HashHistory | MemoryHistory | BrowserHistory {
-    if (historyMode === EHistoryMode.BROWSER) {
-      return createBrowserHistory();
-    }
-    if (historyMode === EHistoryMode.HASH) {
-      return createHashHistory();
-    }
-    if (historyMode === EHistoryMode.MEMORY) {
-      return createMemoryHistory();
-    }
   }
 
   /**

--- a/src/api/CreateRouter.ts
+++ b/src/api/CreateRouter.ts
@@ -72,7 +72,7 @@ export class CreateRouter {
     middlewares,
     base = "/",
     id = 1,
-    history = createBrowserHistory(),
+    history,
   }: {
     base?: string;
     routes: TRoute[];
@@ -83,7 +83,7 @@ export class CreateRouter {
     this.base = base;
     this.id = id;
     this.middlewares = middlewares;
-    this.history = history;
+    this.history = history || createBrowserHistory();
 
     if (!routes) {
       throw new Error(`Router id ${id} > no routes array is set.`);

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,4 +1,4 @@
-import { EHistoryMode, CreateRouter, TRoute, useRouter, langMiddleware } from "..";
+import { CreateRouter, TRoute, useRouter, langMiddleware } from "..";
 import React, {
   createContext,
   memo,
@@ -11,17 +11,23 @@ import { joinPaths } from "../api/helpers";
 import { ROUTERS } from "../api/routers";
 import { LangService } from "..";
 import { getLangPathByPath } from "../lang/langHelpers";
+import {
+  BrowserHistory,
+  createBrowserHistory,
+  HashHistory,
+  MemoryHistory,
+} from "history";
 
 const componentName = "Router";
 const debug = require("debug")(`router:${componentName}`);
 
 interface IProps {
   base: string;
+  history?: BrowserHistory | HashHistory | MemoryHistory;
+  children: ReactElement;
   // routes array is required for 1st instance only
   routes?: TRoute[];
   middlewares?: any[];
-  children: ReactElement;
-  historyMode?: EHistoryMode;
 }
 
 // Router instance will be keep on this context
@@ -80,7 +86,7 @@ export const Router = memo((props: IProps) => {
       routes,
       id,
       middlewares: props.middlewares,
-      historyMode: props.historyMode,
+      history: props.history || createBrowserHistory(),
     });
 
     // keep new router in global constant

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -11,19 +11,14 @@ import { joinPaths } from "../api/helpers";
 import { ROUTERS } from "../api/routers";
 import { LangService } from "..";
 import { getLangPathByPath } from "../lang/langHelpers";
-import {
-  BrowserHistory,
-  createBrowserHistory,
-  HashHistory,
-  MemoryHistory,
-} from "history";
+import { BrowserHistory, HashHistory, MemoryHistory } from "history";
 
 const componentName = "Router";
 const debug = require("debug")(`router:${componentName}`);
 
 interface IProps {
   base: string;
-  history?: BrowserHistory | HashHistory | MemoryHistory;
+  history: BrowserHistory | HashHistory | MemoryHistory;
   children: ReactElement;
   // routes array is required for 1st instance only
   routes?: TRoute[];
@@ -86,7 +81,7 @@ export const Router = memo((props: IProps) => {
       routes,
       id,
       middlewares: props.middlewares,
-      history: props.history || createBrowserHistory(),
+      history: props.history,
     });
 
     // keep new router in global constant

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -18,11 +18,13 @@ const debug = require("debug")(`router:${componentName}`);
 
 interface IProps {
   base: string;
-  history: BrowserHistory | HashHistory | MemoryHistory;
   children: ReactElement;
   // routes array is required for 1st instance only
   routes?: TRoute[];
+  // middleware list (like LangMiddleware)
   middlewares?: any[];
+  // default is BrowserHistory in "CreateRouter"
+  history?: BrowserHistory | HashHistory | MemoryHistory;
 }
 
 // Router instance will be keep on this context

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { CreateRouter, TRoute, ERouterEvent, EHistoryMode } from "./api/CreateRouter";
+export { CreateRouter, TRoute, ERouterEvent } from "./api/CreateRouter";
 
 export { Router } from "./components/Router";
 export { Link } from "./components/Link";
@@ -13,4 +13,3 @@ export { useStack, IRouteStack } from "./hooks/useStack";
 
 export { langMiddleware } from "./lang/LangMiddleware";
 export { default as LangService, TLanguage } from "./lang/LangService";
-

--- a/test/LangService.test.tsx
+++ b/test/LangService.test.tsx
@@ -1,5 +1,6 @@
 import { LangService, langMiddleware, Link, Router, TRoute } from "../src";
 import { act, render } from "@testing-library/react";
+import { createBrowserHistory } from "history";
 import React from "react";
 
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
@@ -10,8 +11,15 @@ const routesList: TRoute[] = [
 
 const mockClickHandler = jest.fn();
 const App = ({ base = "/", to = "/foo" }) => {
+  const history = createBrowserHistory();
+
   return (
-    <Router base={base} routes={routesList} middlewares={[langMiddleware]}>
+    <Router
+      base={base}
+      routes={routesList}
+      history={history}
+      middlewares={[langMiddleware]}
+    >
       <Link
         to={to}
         className={"containerLink"}

--- a/test/Link.test.tsx
+++ b/test/Link.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent } from "@testing-library/react";
 import { ROUTERS } from "../src/api/routers";
 import { LangService } from "../src";
 import { TOpenRouteParams } from "../src/api/helpers";
+import { createBrowserHistory } from "history";
 
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 const routesList: TRoute[] = [
@@ -18,8 +19,9 @@ afterEach(() => {
 
 const mockClickHandler = jest.fn();
 const App = ({ base = "/", to }: { base: string; to: string | TOpenRouteParams }) => {
+  const history = createBrowserHistory();
   return (
-    <Router base={base} routes={routesList}>
+    <Router base={base} routes={routesList} history={history}>
       <Link to={to} className={"containerLink"} onClick={mockClickHandler}>
         Foo
       </Link>

--- a/test/Router.test.tsx
+++ b/test/Router.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Router, TRoute } from "../src";
 import { render } from "@testing-library/react";
+import { createBrowserHistory } from "history";
 
 describe("Router", () => {
   const routesList: TRoute[] = [
@@ -15,8 +16,10 @@ describe("Router", () => {
   });
 
   it("should return a children", () => {
+    const history = createBrowserHistory();
+
     const { container } = render(
-      <Router routes={routesList} base={"/"}>
+      <Router routes={routesList} base={"/"} history={history}>
         <div id={"app"}>app</div>
       </Router>
     );


### PR DESCRIPTION
Change `historyMode` props (enum) to `history` props (`BrowserHistory | HashHistory | MemoryHistory`)

Now we need to create history and pass it as Router props. This props remains optional and `createBrowserHistory()` as default.

```jsx
// ...
import { createBrowserHistory } from "history";
const history = createBrowserHistory();

function App() {
  return (
    <Router routes={...} history={history}>
     // ...
    </Router>
  );
}
```
