### PR TITLE
SSR support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tsconfig.tsbuildinfo
 dist
 example/dist
 .parcel-cache
+example-node

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ src/*
 src/**
 test
 example
+example-node
 .babelrc
 .prettierignore
 .prettierrc

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and [@wbe/debug](https://github.com/willybrauner/debug) as dependencies.
 - [Manage Transitions](#ManageTransitions)
   - [Default sequential transitions](#DefaultSequentialTransitions)
   - [Custom transitions](#CustomTransitions)
+- [SSR support](#SSRSupport)  
 - [Debug](#Debug)
 - [Example](#Example)
 
@@ -342,15 +343,19 @@ const App = (props, handleRef) => {
 
 **[Demo codesandbox: custom manage transitions](https://codesandbox.io/s/inspiring-thompson-tw4qn)**
 
-## <a name="Debug"></a>Debug
+## <a name="SSRSupport"></a>SSR Support
 
-[@wbe/debug](https://github.com/willybrauner/debug) is used on this project. It allows
-to easily get logs informations on development and production modes.
+This router is compatible with SSR due to using `staticLocation` props instead of `history` props on Router instance.
+In this case, the router will match only with `staticLocation` props value and render the appropiate route without invoking the browser history. (Because `window` is not available on the server).
 
-To use it, add this line in your browser console:
-
-```shell
-localStorage.debug = "router:*"
+```jsx
+    <Router 
+      routes={routesList} 
+      staticLocation={"/foo"}
+      // history={createBrowserHistory()}  
+      >
+      // ...
+    </Router>
 ```
 
 ## <a name="Example"></a>Example
@@ -376,7 +381,7 @@ $ npm run dev
 Router component creates a new router instance.
 
 ```jsx
-<Router routes={} base={} history={} middlewares={} id={}>
+<Router routes={} base={} history={} staticLocation={} middlewares={} id={}>
   {/* can now use <Link /> and <Stack /> component */}
 </Router>
 ```
@@ -394,8 +399,9 @@ Router component creates a new router instance.
   [MEMORY](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md#creatememoryhistory)
   . For more information, check
   the [history library documentation](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md)
-- **middlewares** `[]` add routes middleware function to patch each routes)
-- **id** `?number | string`
+- **staticLocation** `string` _(optional)_  use static URL location matching instead of history
+- **middlewares** `[]`  _(optional)_ add routes middleware function to patch each routes)
+- **id** `?number | string`  _(optional)_ id of the router instance - default : `1`
 
 ### <a name="Link"></a>Link
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,7 +7,7 @@ const componentName = "App";
  */
 export default function App() {
   const [lang, setLang] = useLang();
-  const [location, setLocation] = useLocation()
+  const [location, setLocation] = useLocation();
 
   const customSenario = ({
     previousPage,

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,10 +1,11 @@
-import { createRoot } from "react-dom/client"
+import { createRoot } from "react-dom/client";
 import React from "react";
 import "./index.css";
 import App from "./App";
 import { Router } from "../src/components/Router";
 import { routesList } from "./routes";
 import { LangService } from "../src";
+import { createBrowserHistory } from "history";
 
 const base = "/base/";
 type TLang = "en" | "fr" | "de";
@@ -18,10 +19,16 @@ const langService = new LangService<TLang>({
 /**
  * Init Application
  */
- const root = createRoot(document.getElementById("root"))
+const root = createRoot(document.getElementById("root"));
 
 root.render(
-  <Router langService={langService} routes={routesList} base={base}>
+  <Router
+    history={createBrowserHistory()}
+    // staticLocation="/base/en/about"
+    langService={langService}
+    routes={routesList}
+    base={base}
+  >
     <App />
   </Router>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cher-ami/router",
-  "version": "2.1.0-beta.0",
+  "version": "3.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cher-ami/router",
-      "version": "2.1.0-beta.0",
+      "version": "3.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@wbe/debug": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cher-ami/router",
-  "version": "2.0.1",
+  "version": "2.1.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cher-ami/router",
-      "version": "2.0.1",
+      "version": "2.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@wbe/debug": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cher-ami/router",
-  "version": "2.0.1",
+  "version": "2.1.0-beta.0",
   "description": "A fresh react router designed for flexible route transitions",
   "author": "Willy Brauner",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cher-ami/router",
-  "version": "2.1.0-beta.0",
+  "version": "3.0.0-beta.0",
   "description": "A fresh react router designed for flexible route transitions",
   "author": "Willy Brauner",
   "license": "MIT",

--- a/src/components/Link.test.tsx
+++ b/src/components/Link.test.tsx
@@ -7,6 +7,7 @@ import { Routers } from "../core/Routers";
 import LangService from "../core/LangService";
 import { TOpenRouteParams } from "../core/helpers";
 import { TRoute } from "./Router";
+import { createBrowserHistory } from "history";
 
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 const routesList: TRoute[] = [
@@ -24,7 +25,8 @@ const App = ({ base = "/", to }: { base: string; to: string | TOpenRouteParams }
   });
 
   return (
-    <Router langService={langService} base={base} routes={routesList}>
+    <Router langService={langService} base={base} routes={routesList} history={createBrowserHistory()}
+    >
       <Link to={to} className={"containerLink"} onClick={mockClickHandler}>
         Foo
       </Link>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,4 +1,9 @@
-import React, { AnchorHTMLAttributes, PropsWithChildren, useMemo } from "react";
+import React, {
+  AnchorHTMLAttributes,
+  MutableRefObject,
+  PropsWithChildren,
+  useMemo,
+} from "react";
 import {
   createUrl,
   joinPaths,
@@ -24,7 +29,7 @@ const log = debug("router:Link");
 /**
  * @name Link
  */
-function Link(props: ILinkProps) {
+function Link(props: ILinkProps, ref: MutableRefObject<any>) {
   const { history, staticLocation } = useRouter();
   const [location] = useLocation();
 
@@ -32,28 +37,29 @@ function Link(props: ILinkProps) {
   const url = useMemo(() => createUrl(props.to), [props.to]);
 
   // Link is active if its URL is the current URL
-
   const handleClick = (event): void => {
     event.preventDefault();
     props.onClick?.();
     history?.push(url);
   };
 
-  // FIXME re add active link
-  // const isActive = useMemo(() => {
-  //   const l = history ? location : staticLocation;
-  //   return l === url || l === removeLastCharFromString(url, "/", true);
-  // }, [history, staticLocation, location, url]);
+  // const prepare active link
+  const isActive = useMemo(() => {
+    const l = history ? location : staticLocation;
+    return l === url || l === removeLastCharFromString(url, "/", true);
+  }, [history, staticLocation, location, url]);
 
   return (
     <a
       {...{ ...props, to: undefined }}
-      className={joinPaths(["Link", props.className], " ")}
+      className={joinPaths(["Link", props.className, isActive && "active"], " ")}
       onClick={handleClick}
       children={props.children}
       href={url}
+      ref={ref}
     />
   );
 }
 
-export { Link };
+const ForwardLink = React.forwardRef(Link);
+export { ForwardLink as Link };

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -32,11 +32,6 @@ function Link(props: ILinkProps) {
   const url = useMemo(() => createUrl(props.to), [props.to]);
 
   // Link is active if its URL is the current URL
-  const isActive = useMemo(() => {
-    const l = history ? location : staticLocation;
-    return l === url || l === removeLastCharFromString(url, "/", true);
-  }, [history, staticLocation, location, url]);
-
 
   const handleClick = (event): void => {
     event.preventDefault();
@@ -44,10 +39,16 @@ function Link(props: ILinkProps) {
     history?.push(url);
   };
 
+  // FIXME re add active link
+  // const isActive = useMemo(() => {
+  //   const l = history ? location : staticLocation;
+  //   return l === url || l === removeLastCharFromString(url, "/", true);
+  // }, [history, staticLocation, location, url]);
+
   return (
     <a
       {...{ ...props, to: undefined }}
-      className={joinPaths(["Link", props.className, isActive && "active"], " ")}
+      className={joinPaths(["Link", props.className], " ")}
       onClick={handleClick}
       children={props.children}
       href={url}

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -16,6 +16,7 @@ export interface ILinkProps extends PropsWithChildren<TAnchorWithoutHref> {
   to: string | TOpenRouteParams;
   onClick?: () => void;
   className?: string;
+  children?: React.ReactNode;
 }
 
 const log = debug("router:Link");
@@ -24,17 +25,18 @@ const log = debug("router:Link");
  * @name Link
  */
 function Link(props: ILinkProps) {
-  const { history } = useRouter();
+  const { history, staticLocation } = useRouter();
   const [location] = useLocation();
 
   // Compute URL
   const url = useMemo(() => createUrl(props.to), [props.to]);
 
   // Link is active if its URL is the current URL
-  const isActive = useMemo(
-    () => location === url || location === removeLastCharFromString(url, "/", true),
-    [location, url]
-  );
+  const isActive = useMemo(() => {
+    const l = history ? location : staticLocation;
+    return l === url || l === removeLastCharFromString(url, "/", true);
+  }, [history, staticLocation, location, url]);
+
 
   const handleClick = (event): void => {
     event.preventDefault();

--- a/src/components/Router.test.tsx
+++ b/src/components/Router.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Router } from "./Router";
 import { render } from "@testing-library/react";
 import { TRoute } from "./Router";
+import { createBrowserHistory } from "history";
+
 
 describe("Router", () => {
   const routesList: TRoute[] = [
@@ -17,7 +19,7 @@ describe("Router", () => {
 
   it("should return a children", () => {
     const { container } = render(
-      <Router routes={routesList}>
+      <Router routes={routesList} history={createBrowserHistory()}>
         <div id={"app"}>app</div>
       </Router>
     );

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,62 +1,62 @@
-import debug from "@wbe/debug"
-import { BrowserHistory, HashHistory, MemoryHistory } from "history"
-import { Match } from "path-to-regexp"
-import React from "react"
-import { applyMiddlewares, patchMissingRootRoute } from "../core/helpers"
-import { getNotFoundRoute, getRouteFromUrl } from "../core/matcher"
-import { Routers } from "../core/Routers"
-import LangService from "../core/LangService"
+import debug from "@wbe/debug";
+import { BrowserHistory, HashHistory, MemoryHistory } from "history";
+import { Match } from "path-to-regexp";
+import React from "react";
+import { applyMiddlewares, patchMissingRootRoute } from "../core/helpers";
+import { getNotFoundRoute, getRouteFromUrl } from "../core/matcher";
+import { Routers } from "../core/Routers";
+import LangService from "../core/LangService";
 
 // -------------------------------------------------------------------------------- TYPES
 
 export type TRoute = {
-  path: string | { [x: string]: string }
-  component?: React.ComponentType<any>
-  base?: string
-  name?: string
-  parser?: Match
+  path: string | { [x: string]: string };
+  component?: React.ComponentType<any>;
+  base?: string;
+  name?: string;
+  parser?: Match;
   props?: {
-    params?: { [x: string]: any }
-    [x: string]: any
-  }
-  children?: TRoute[]
-  url?: string
-  fullUrl?: string // full URL who not depend of current instance
-  fullPath?: string // full Path /base/:lang/foo/second-foo
-  langPath?: { [x: string]: string } | null
-}
+    params?: { [x: string]: any };
+    [x: string]: any;
+  };
+  children?: TRoute[];
+  url?: string;
+  fullUrl?: string; // full URL who not depend of current instance
+  fullPath?: string; // full Path /base/:lang/foo/second-foo
+  langPath?: { [x: string]: string } | null;
+};
 
 export interface IRouterContextStackStates {
-  unmountPreviousPage?: () => void
-  previousPageIsMount?: boolean
+  unmountPreviousPage?: () => void;
+  previousPageIsMount?: boolean;
 }
 
 export interface IRouterContext extends IRouterContextStackStates {
-  base: string
-  routes: TRoute[]
-  history: BrowserHistory | HashHistory | MemoryHistory | undefined
-  staticLocation: string
-  currentRoute: TRoute
-  previousRoute: TRoute
-  langService: LangService
-  routeIndex: number
-  previousPageIsMount: boolean
-  unmountPreviousPage: () => void
-  getPaused: () => boolean
-  setPaused: (value: boolean) => void
+  base: string;
+  routes: TRoute[];
+  history: BrowserHistory | HashHistory | MemoryHistory | undefined;
+  staticLocation: string;
+  currentRoute: TRoute;
+  previousRoute: TRoute;
+  langService: LangService;
+  routeIndex: number;
+  previousPageIsMount: boolean;
+  unmountPreviousPage: () => void;
+  getPaused: () => boolean;
+  setPaused: (value: boolean) => void;
 }
 
 export type TRouteReducerState = {
-  currentRoute: TRoute
-  previousRoute: TRoute
-  previousPageIsMount: boolean
-  index: number
-}
+  currentRoute: TRoute;
+  previousRoute: TRoute;
+  previousPageIsMount: boolean;
+  index: number;
+};
 
 // -------------------------------------------------------------------------------- PREPARE / CONTEXT
 
-const componentName = "Router"
-const log = debug(`router:${componentName}`)
+const componentName = "Router";
+const log = debug(`router:${componentName}`);
 
 /**
  * Router Context
@@ -77,13 +77,13 @@ export const RouterContext = React.createContext<IRouterContext>({
   unmountPreviousPage: () => {},
   getPaused: () => false,
   setPaused: (value: boolean) => {},
-})
-RouterContext.displayName = "RouterContext"
+});
+RouterContext.displayName = "RouterContext";
 
 Router.defaultProps = {
   base: "/",
   id: 1,
-}
+};
 
 // -------------------------------------------------------------------------------- COMPONENT
 
@@ -93,14 +93,14 @@ Router.defaultProps = {
  * @returns JSX.Element
  */
 function Router(props: {
-  children: React.ReactNode
-  routes: TRoute[]
-  base: string
-  history?: BrowserHistory | HashHistory | MemoryHistory | undefined
-  staticLocation?: string
-  middlewares?: ((routes: TRoute[]) => TRoute[])[]
-  langService?: LangService
-  id?: number | string
+  children: React.ReactNode;
+  routes: TRoute[];
+  base: string;
+  history?: BrowserHistory | HashHistory | MemoryHistory | undefined;
+  staticLocation?: string;
+  middlewares?: ((routes: TRoute[]) => TRoute[])[];
+  langService?: LangService;
+  id?: number | string;
 }): JSX.Element {
   /**
    * 0. LangService
@@ -108,9 +108,9 @@ function Router(props: {
    * If props exist, store langService instance in Routers store.
    */
   const langService = React.useMemo(() => {
-    if (!Routers.langService) Routers.langService = props.langService
-    return Routers.langService
-  }, [props.langService])
+    if (!Routers.langService) Routers.langService = props.langService;
+    return Routers.langService;
+  }, [props.langService]);
 
   /**
    * 1. routes
@@ -123,23 +123,23 @@ function Router(props: {
    */
   const routes = React.useMemo(() => {
     if (!props.routes) {
-      console.error(props.id, "props.routes is missing or empty, return.", props)
-      return
+      console.error(props.id, "props.routes is missing or empty, return.", props);
+      return;
     }
-    let routesList
+    let routesList;
 
     // For each instances
-    routesList = patchMissingRootRoute(props.routes)
+    routesList = patchMissingRootRoute(props.routes);
 
     // Only for first instance
     if (!Routers.routes) {
-      routesList = applyMiddlewares(routesList, props.middlewares)
-      if (langService) routesList = langService.addLangParamToRoutes(routesList)
-      Routers.routes = routesList
+      routesList = applyMiddlewares(routesList, props.middlewares);
+      if (langService) routesList = langService.addLangParamToRoutes(routesList);
+      Routers.routes = routesList;
     }
-    log(props.id, "routesList", routesList)
-    return routesList
-  }, [props.routes, langService])
+    log(props.id, "routesList", routesList);
+    return routesList;
+  }, [props.routes, langService]);
 
   /**
    * 2. base
@@ -148,9 +148,9 @@ function Router(props: {
    * In all case, return current props.base
    */
   const base = React.useMemo(() => {
-    if (!Routers.base) Routers.base = props.base
-    return props.base
-  }, [props.base])
+    if (!Routers.base) Routers.base = props.base;
+    return props.base;
+  }, [props.base]);
 
   /**
    * 3. history
@@ -159,21 +159,21 @@ function Router(props: {
    */
   const history = React.useMemo(() => {
     if (props.history && !Routers.history) {
-      Routers.history = props.history
+      Routers.history = props.history;
     }
-    return Routers.history
-  }, [props.history])
+    return Routers.history;
+  }, [props.history]);
 
   /**
    * 4 static location
    * Is useful in SSR context
    */
   const staticLocation = React.useMemo((): string | undefined => {
-    if (props.staticLocation && !Routers.staticLocation) {
-      Routers.staticLocation = props.staticLocation
+    if (props.staticLocation) {
+      Routers.staticLocation = props.staticLocation;
     }
-    return Routers.staticLocation
-  }, [props.staticLocation])
+    return Routers.staticLocation;
+  }, [props.staticLocation]);
 
   // -------------------------------------------------------------------------------- ROUTE CHANGE
 
@@ -193,9 +193,9 @@ function Router(props: {
             currentRoute: action.value,
             routeIndex: state.routeIndex + 1,
             previousPageIsMount: true,
-          }
+          };
         case "unmount-previous-page":
-          return { ...state, previousPageIsMount: false }
+          return { ...state, previousPageIsMount: false };
       }
     },
     {
@@ -204,23 +204,23 @@ function Router(props: {
       previousPageIsMount: false,
       routeIndex: 0,
     }
-  )
+  );
 
   /**
    * Enable paused on Router instance
    */
-  const _waitingUrl = React.useRef(null)
-  const _paused = React.useRef<boolean>(false)
-  const getPaused = () => _paused.current
+  const _waitingUrl = React.useRef(null);
+  const _paused = React.useRef<boolean>(false);
+  const getPaused = () => _paused.current;
   const setPaused = (value: boolean) => {
-    _paused.current = value
+    _paused.current = value;
     if (!value && _waitingUrl.current) {
-      handleHistory(_waitingUrl.current)
-      _waitingUrl.current = null
+      handleHistory(_waitingUrl.current);
+      _waitingUrl.current = null;
     }
-  }
+  };
 
-  const currentRouteRef = React.useRef<TRoute>()
+  const currentRouteRef = React.useRef<TRoute>();
 
   /**
    * Handle history
@@ -229,8 +229,8 @@ function Router(props: {
    */
   const handleHistory = (url: string = ""): void => {
     if (_paused.current) {
-      _waitingUrl.current = url
-      return
+      _waitingUrl.current = url;
+      return;
     }
 
     const matchingRoute = getRouteFromUrl({
@@ -238,29 +238,29 @@ function Router(props: {
       pRoutes: routes,
       pBase: props.base,
       id: props.id,
-    })
+    });
 
-    const notFoundRoute = getNotFoundRoute(props.routes)
+    const notFoundRoute = getNotFoundRoute(props.routes);
     if (!matchingRoute && !notFoundRoute) {
-      log(props.id, "matchingRoute not found & 'notFoundRoute' not found, return.")
-      return
+      log(props.id, "matchingRoute not found & 'notFoundRoute' not found, return.");
+      return;
     }
 
-    const currentRouteUrl = currentRouteRef.current?.url
+    const currentRouteUrl = currentRouteRef.current?.url;
     if (currentRouteUrl != null && currentRouteUrl === matchingRoute?.url) {
-      log(props.id, "this is the same route 'url', return.")
-      return
+      log(props.id, "this is the same route 'url', return.");
+      return;
     }
 
-    const newRoute: TRoute = matchingRoute || notFoundRoute
+    const newRoute: TRoute = matchingRoute || notFoundRoute;
     if (newRoute) {
       // Final process: update context currentRoute from dispatch method \o/ !
-      dispatch({ type: "update-current-route", value: newRoute })
+      dispatch({ type: "update-current-route", value: newRoute });
       // & register this new route as currentRoute in local and in Routers store
-      currentRouteRef.current = newRoute
-      Routers.currentRoute = newRoute
+      currentRouteRef.current = newRoute;
+      Routers.currentRoute = newRoute;
     }
-  }
+  };
 
   /**
    * Here we go!
@@ -269,31 +269,36 @@ function Router(props: {
    * - Get matching route with current URL
    * - Dispatch new routes states from RouterContext
    */
+
+  const historyListener = React.useMemo(() => {
+    // server
+    if (staticLocation) {
+      handleHistory(staticLocation);
+      return;
+      // client
+    } else if (history) {
+      handleHistory(window.location.pathname);
+      return history?.listen(({ location }) => {
+        handleHistory(location.pathname);
+      });
+      // log warn
+    } else {
+      console.warn(`
+          An history or staticLocation props is required.
+          ex: <Router history={createBrowserHistory()}>...</Router>
+        `);
+      return;
+    }
+  }, [staticLocation, history]);
+
   React.useEffect(() => {
-      // server
-      if (staticLocation) {
-        handleHistory(staticLocation)
-        return
-        // client
-      } else if (history) {
-        handleHistory(window.location.pathname)
-        return history?.listen(({ location }) => {
-          handleHistory(location.pathname)
-        })
-        // log warn
-      } else {
-        console.warn(`
-            An history or staticLocation props is required.
-            ex: <Router history={createBrowserHistory()}>...</Router>
-          `)
-        return
-      }
-  }, [staticLocation, history])
+    return historyListener;
+  }, []);
 
   // -------------------------------------------------------------------------------- RENDER
 
-  const { currentRoute, previousRoute, routeIndex, previousPageIsMount } = reducerState
-  const unmountPreviousPage = () => dispatch({ type: "unmount-previous-page" })
+  const { currentRoute, previousRoute, routeIndex, previousPageIsMount } = reducerState;
+  const unmountPreviousPage = () => dispatch({ type: "unmount-previous-page" });
 
   return (
     <RouterContext.Provider
@@ -313,9 +318,9 @@ function Router(props: {
         setPaused,
       }}
     />
-  )
+  );
 }
 
-Router.displayName = componentName
-const MemoizedRouter = React.memo(Router)
-export { MemoizedRouter as Router }
+Router.displayName = componentName;
+const MemoizedRouter = React.memo(Router);
+export { MemoizedRouter as Router };

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -269,30 +269,26 @@ function Router(props: {
    * - Get matching route with current URL
    * - Dispatch new routes states from RouterContext
    */
-  const historyListener = React.useMemo(() => {
-    // server
-    if (staticLocation) {
-      handleHistory(staticLocation)
-      return
-      // client
-    } else if (history) {
-      handleHistory(window.location.pathname)
-      return history?.listen(({ location }) => {
-        handleHistory(location.pathname)
-      })
-      // log warn
-    } else {
-      console.warn(`
-          An history or staticLocation props is required.
-          ex: <Router history={createBrowserHistory()}>...</Router>
-        `)
-      return
-    }
-  }, [staticLocation, history])
-
   React.useEffect(() => {
-    return historyListener
-  }, [])
+      // server
+      if (staticLocation) {
+        handleHistory(staticLocation)
+        return
+        // client
+      } else if (history) {
+        handleHistory(window.location.pathname)
+        return history?.listen(({ location }) => {
+          handleHistory(location.pathname)
+        })
+        // log warn
+      } else {
+        console.warn(`
+            An history or staticLocation props is required.
+            ex: <Router history={createBrowserHistory()}>...</Router>
+          `)
+        return
+      }
+  }, [staticLocation, history])
 
   // -------------------------------------------------------------------------------- RENDER
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,66 +1,62 @@
-import debug from "@wbe/debug";
-import {
-  BrowserHistory,
-  createBrowserHistory,
-  HashHistory,
-  MemoryHistory,
-} from "history";
-import { Match } from "path-to-regexp";
-import React, { useState } from "react";
-import { applyMiddlewares, patchMissingRootRoute } from "../core/helpers";
-import { getNotFoundRoute, getRouteFromUrl } from "../core/matcher";
-import { Routers } from "../core/Routers";
-import LangService from "../core/LangService";
+import debug from "@wbe/debug"
+import { BrowserHistory, HashHistory, MemoryHistory } from "history"
+import { Match } from "path-to-regexp"
+import React from "react"
+import { applyMiddlewares, patchMissingRootRoute } from "../core/helpers"
+import { getNotFoundRoute, getRouteFromUrl } from "../core/matcher"
+import { Routers } from "../core/Routers"
+import LangService from "../core/LangService"
 
 // -------------------------------------------------------------------------------- TYPES
 
 export type TRoute = {
-  path: string | { [x: string]: string };
-  component?: React.ComponentType<any>;
-  base?: string;
-  name?: string;
-  parser?: Match;
+  path: string | { [x: string]: string }
+  component?: React.ComponentType<any>
+  base?: string
+  name?: string
+  parser?: Match
   props?: {
-    params?: { [x: string]: any };
-    [x: string]: any;
-  };
-  children?: TRoute[];
-  url?: string;
-  fullUrl?: string; // full URL who not depend of current instance
-  fullPath?: string; // full Path /base/:lang/foo/second-foo
-  langPath?: { [x: string]: string } | null;
-};
+    params?: { [x: string]: any }
+    [x: string]: any
+  }
+  children?: TRoute[]
+  url?: string
+  fullUrl?: string // full URL who not depend of current instance
+  fullPath?: string // full Path /base/:lang/foo/second-foo
+  langPath?: { [x: string]: string } | null
+}
 
 export interface IRouterContextStackStates {
-  unmountPreviousPage?: () => void;
-  previousPageIsMount?: boolean;
+  unmountPreviousPage?: () => void
+  previousPageIsMount?: boolean
 }
 
 export interface IRouterContext extends IRouterContextStackStates {
-  base: string;
-  routes: TRoute[];
-  history: BrowserHistory | HashHistory | MemoryHistory;
-  currentRoute: TRoute;
-  previousRoute: TRoute;
-  langService: LangService;
-  routeIndex: number;
-  previousPageIsMount: boolean;
-  unmountPreviousPage: () => void;
-  getPaused: () => boolean;
-  setPaused: (value: boolean) => void;
+  base: string
+  routes: TRoute[]
+  history: BrowserHistory | HashHistory | MemoryHistory | undefined
+  staticLocation: string
+  currentRoute: TRoute
+  previousRoute: TRoute
+  langService: LangService
+  routeIndex: number
+  previousPageIsMount: boolean
+  unmountPreviousPage: () => void
+  getPaused: () => boolean
+  setPaused: (value: boolean) => void
 }
 
 export type TRouteReducerState = {
-  currentRoute: TRoute;
-  previousRoute: TRoute;
-  previousPageIsMount: boolean;
-  index: number;
-};
+  currentRoute: TRoute
+  previousRoute: TRoute
+  previousPageIsMount: boolean
+  index: number
+}
 
 // -------------------------------------------------------------------------------- PREPARE / CONTEXT
 
-const componentName = "Router";
-const log = debug(`router:${componentName}`);
+const componentName = "Router"
+const log = debug(`router:${componentName}`)
 
 /**
  * Router Context
@@ -77,17 +73,17 @@ export const RouterContext = React.createContext<IRouterContext>({
   previousRoute: undefined,
   routeIndex: 0,
   previousPageIsMount: true,
+  staticLocation: undefined,
   unmountPreviousPage: () => {},
   getPaused: () => false,
   setPaused: (value: boolean) => {},
-});
-RouterContext.displayName = "RouterContext";
+})
+RouterContext.displayName = "RouterContext"
 
 Router.defaultProps = {
   base: "/",
-  history: createBrowserHistory(),
   id: 1,
-};
+}
 
 // -------------------------------------------------------------------------------- COMPONENT
 
@@ -97,13 +93,14 @@ Router.defaultProps = {
  * @returns JSX.Element
  */
 function Router(props: {
-  children: React.ReactNode;
-  routes: TRoute[];
-  base: string;
-  history?: BrowserHistory | HashHistory | MemoryHistory;
-  middlewares?: ((routes: TRoute[]) => TRoute[])[];
-  langService?: LangService;
-  id?: number | string;
+  children: React.ReactNode
+  routes: TRoute[]
+  base: string
+  history?: BrowserHistory | HashHistory | MemoryHistory | undefined
+  staticLocation?: string
+  middlewares?: ((routes: TRoute[]) => TRoute[])[]
+  langService?: LangService
+  id?: number | string
 }): JSX.Element {
   /**
    * 0. LangService
@@ -111,9 +108,9 @@ function Router(props: {
    * If props exist, store langService instance in Routers store.
    */
   const langService = React.useMemo(() => {
-    if (!Routers.langService) Routers.langService = props.langService;
-    return Routers.langService;
-  }, [props.langService]);
+    if (!Routers.langService) Routers.langService = props.langService
+    return Routers.langService
+  }, [props.langService])
 
   /**
    * 1. routes
@@ -126,23 +123,23 @@ function Router(props: {
    */
   const routes = React.useMemo(() => {
     if (!props.routes) {
-      console.error(props.id, "props.routes is missing or empty, return.", props);
-      return;
+      console.error(props.id, "props.routes is missing or empty, return.", props)
+      return
     }
-    let routesList;
+    let routesList
 
     // For each instances
-    routesList = patchMissingRootRoute(props.routes);
+    routesList = patchMissingRootRoute(props.routes)
 
     // Only for first instance
     if (!Routers.routes) {
-      routesList = applyMiddlewares(routesList, props.middlewares);
-      if (langService) routesList = langService.addLangParamToRoutes(routesList);
-      Routers.routes = routesList;
+      routesList = applyMiddlewares(routesList, props.middlewares)
+      if (langService) routesList = langService.addLangParamToRoutes(routesList)
+      Routers.routes = routesList
     }
-    log(props.id, "routesList", routesList);
-    return routesList;
-  }, [props.routes, langService]);
+    log(props.id, "routesList", routesList)
+    return routesList
+  }, [props.routes, langService])
 
   /**
    * 2. base
@@ -151,16 +148,32 @@ function Router(props: {
    * In all case, return current props.base
    */
   const base = React.useMemo(() => {
-    if (!Routers.base) Routers.base = props.base;
-    return props.base;
-  }, [props.base]);
+    if (!Routers.base) Routers.base = props.base
+    return props.base
+  }, [props.base])
 
   /**
    * 3. history
    * If is the first Router instance, register history in 'Routers' store
    * 'history' object need to be the same between each Router instance
    */
-  if (!Routers.history) Routers.history = props.history;
+  const history = React.useMemo(() => {
+    if (props.history && !Routers.history) {
+      Routers.history = props.history
+    }
+    return Routers.history
+  }, [props.history])
+
+  /**
+   * 4 static location
+   * Is useful in SSR context
+   */
+  const staticLocation = React.useMemo((): string | undefined => {
+    if (props.staticLocation && !Routers.staticLocation) {
+      Routers.staticLocation = props.staticLocation
+    }
+    return Routers.staticLocation
+  }, [props.staticLocation])
 
   // -------------------------------------------------------------------------------- ROUTE CHANGE
 
@@ -180,9 +193,9 @@ function Router(props: {
             currentRoute: action.value,
             routeIndex: state.routeIndex + 1,
             previousPageIsMount: true,
-          };
+          }
         case "unmount-previous-page":
-          return { ...state, previousPageIsMount: false };
+          return { ...state, previousPageIsMount: false }
       }
     },
     {
@@ -191,33 +204,33 @@ function Router(props: {
       previousPageIsMount: false,
       routeIndex: 0,
     }
-  );
+  )
 
   /**
    * Enable paused on Router instance
    */
-  const _waitingUrl = React.useRef(null);
-  const _paused = React.useRef<boolean>(false);
-  const getPaused = () => _paused.current;
+  const _waitingUrl = React.useRef(null)
+  const _paused = React.useRef<boolean>(false)
+  const getPaused = () => _paused.current
   const setPaused = (value: boolean) => {
-    _paused.current = value;
+    _paused.current = value
     if (!value && _waitingUrl.current) {
-      handleHistory(_waitingUrl.current);
-      _waitingUrl.current = null;
+      handleHistory(_waitingUrl.current)
+      _waitingUrl.current = null
     }
-  };
-  
-  const currentRouteRef = React.useRef<TRoute>();
+  }
+
+  const currentRouteRef = React.useRef<TRoute>()
 
   /**
    * Handle history
    * Update routes when history change
    * Dispatch new routes via RouterContext
    */
-  const handleHistory = (url: string = window.location.pathname): void => {
+  const handleHistory = (url: string = ""): void => {
     if (_paused.current) {
-      _waitingUrl.current = url;
-      return;
+      _waitingUrl.current = url
+      return
     }
 
     const matchingRoute = getRouteFromUrl({
@@ -225,29 +238,29 @@ function Router(props: {
       pRoutes: routes,
       pBase: props.base,
       id: props.id,
-    });
+    })
 
-    const notFoundRoute = getNotFoundRoute(props.routes);
+    const notFoundRoute = getNotFoundRoute(props.routes)
     if (!matchingRoute && !notFoundRoute) {
-      log(props.id, "matchingRoute not found & 'notFoundRoute' not found, return.");
-      return;
+      log(props.id, "matchingRoute not found & 'notFoundRoute' not found, return.")
+      return
     }
 
-    const currentRouteUrl = currentRouteRef.current?.url;
+    const currentRouteUrl = currentRouteRef.current?.url
     if (currentRouteUrl != null && currentRouteUrl === matchingRoute?.url) {
-      log(props.id, "this is the same route 'url', return.");
-      return;
+      log(props.id, "this is the same route 'url', return.")
+      return
     }
 
-    const newRoute: TRoute = matchingRoute || notFoundRoute;
+    const newRoute: TRoute = matchingRoute || notFoundRoute
     if (newRoute) {
       // Final process: update context currentRoute from dispatch method \o/ !
-      dispatch({ type: "update-current-route", value: newRoute });
+      dispatch({ type: "update-current-route", value: newRoute })
       // & register this new route as currentRoute in local and in Routers store
-      currentRouteRef.current = newRoute;
-      Routers.currentRoute = newRoute;
+      currentRouteRef.current = newRoute
+      Routers.currentRoute = newRoute
     }
-  };
+  }
 
   /**
    * Here we go!
@@ -256,17 +269,35 @@ function Router(props: {
    * - Get matching route with current URL
    * - Dispatch new routes states from RouterContext
    */
+  const historyListener = React.useMemo(() => {
+    // server
+    if (staticLocation) {
+      handleHistory(staticLocation)
+      return
+      // client
+    } else if (history) {
+      handleHistory(window.location.pathname)
+      return history?.listen(({ location }) => {
+        handleHistory(location.pathname)
+      })
+      // log warn
+    } else {
+      console.warn(`
+          An history or staticLocation props is required.
+          ex: <Router history={createBrowserHistory()}>...</Router>
+        `)
+      return
+    }
+  }, [staticLocation, history])
+
   React.useEffect(() => {
-    handleHistory();
-    return Routers.history.listen(({ location }) => {
-      handleHistory(location.pathname);
-    });
-  }, []);
+    return historyListener
+  }, [])
 
   // -------------------------------------------------------------------------------- RENDER
 
-  const { currentRoute, previousRoute, routeIndex, previousPageIsMount } = reducerState;
-  const unmountPreviousPage = () => dispatch({ type: "unmount-previous-page" });
+  const { currentRoute, previousRoute, routeIndex, previousPageIsMount } = reducerState
+  const unmountPreviousPage = () => dispatch({ type: "unmount-previous-page" })
 
   return (
     <RouterContext.Provider
@@ -275,7 +306,8 @@ function Router(props: {
         routes,
         base,
         langService,
-        history: Routers.history,
+        history,
+        staticLocation,
         currentRoute,
         previousRoute,
         routeIndex,
@@ -285,9 +317,9 @@ function Router(props: {
         setPaused,
       }}
     />
-  );
+  )
 }
 
-Router.displayName = componentName;
-const MemoizedRouter = React.memo(Router);
-export { MemoizedRouter as Router };
+Router.displayName = componentName
+const MemoizedRouter = React.memo(Router)
+export { MemoizedRouter as Router }

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -23,6 +23,7 @@ const log = debug(`router:${componentName}`);
  */
 function Stack(props: IProps): JSX.Element {
   const {
+    staticLocation,
     routeIndex,
     currentRoute,
     previousRoute,
@@ -61,9 +62,8 @@ function Stack(props: IProps): JSX.Element {
 
   // 2. animate when route state changed
   // need to be "layoutEffect" to play transitions before render, to avoid screen "clip"
-  React.useLayoutEffect(() => {
+  React[staticLocation ? "useEffect" : "useLayoutEffect"](() => {
     if (!currentRoute) return;
-
     (props.manageTransitions || sequencialTransition)({
       previousPage: prevRef.current,
       currentPage: currentRef.current,

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -61,7 +61,6 @@ function Stack(props: IProps): JSX.Element {
   );
 
   // 2. animate when route state changed
-  // need to be "layoutEffect" to play transitions before render, to avoid screen "clip"
   React[staticLocation ? "useEffect" : "useLayoutEffect"](() => {
     if (!currentRoute) return;
     (props.manageTransitions || sequencialTransition)({

--- a/src/core/LangService.test.tsx
+++ b/src/core/LangService.test.tsx
@@ -4,6 +4,7 @@ import LangService from "../core/LangService";
 import { Link } from "../components/Link";
 import { act, render } from "@testing-library/react";
 import { TRoute } from "../components/Router";
+import { createBrowserHistory } from "history";
 
 const locales = [{ key: "en" }, { key: "fr" }, { key: "de" }];
 const routesList: TRoute[] = [
@@ -14,7 +15,12 @@ const routesList: TRoute[] = [
 const mockClickHandler = jest.fn();
 const App = ({ base = "/", to = "/foo", langService }) => {
   return (
-    <Router base={base} routes={routesList} langService={langService}>
+    <Router
+      base={base}
+      routes={routesList}
+      langService={langService}
+      history={createBrowserHistory()}
+    >
       <Link
         to={to}
         className={"containerLink"}

--- a/src/core/LangService.ts
+++ b/src/core/LangService.ts
@@ -335,7 +335,7 @@ class LangService<TLang = any> {
    * @protected
    */
   protected reloadOrRefresh(newUrl: string, forcePageReload = true): void {
-    forcePageReload ? window.open(newUrl, "_self") : Routers.history.push(newUrl);
+    forcePageReload ? window?.open(newUrl, "_self") : Routers.history.push(newUrl);
   }
 }
 

--- a/src/core/Routers.ts
+++ b/src/core/Routers.ts
@@ -16,6 +16,10 @@ export type TRouters = {
    */
   history: HashHistory | MemoryHistory | BrowserHistory;
   /**
+   * Global static location
+   */
+  staticLocation: string;
+  /**
    * Global route counter increment on each history push
    */
   routeCounter: number;
@@ -24,13 +28,11 @@ export type TRouters = {
    * Is first route is true if routerCounter === 1
    */
   isFirstRoute: boolean;
-
   /**
    * Store current route
    * Allows to always know what is last currentRoute path (for LangSerivce)
    */
   currentRoute: TRoute;
-
   /**
    * LangService instance (stored in Router)
    */
@@ -45,6 +47,7 @@ export const Routers: TRouters = {
   base: undefined,
   routes: undefined,
   history: undefined,
+  staticLocation: undefined,
   routeCounter: 1,
   isFirstRoute: true,
   currentRoute: undefined,

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -2,18 +2,21 @@ import { useState } from "react";
 import { useHistory } from "../hooks/useHistory";
 import { createUrl, TOpenRouteParams } from "../core/helpers";
 import debug from "@wbe/debug";
+import { useRouter } from "./useRouter";
 const log = debug("router:useLocation");
 
 /**
  * useLocation
  */
 export const useLocation = (): [string, (param: string | TOpenRouteParams) => void] => {
+  const { staticLocation } = useRouter();
+  
   const history = useHistory((event) => {
     setPathname(event.location.pathname);
   }, []);
 
   // Get dynamic current location
-  const [pathname, setPathname] = useState(window.location.pathname);
+  const [pathname, setPathname] = useState(staticLocation || history?.location.pathname);
 
   // Prepare setLocation function, who push in history
   function setLocation(args: string & TOpenRouteParams): void {


### PR DESCRIPTION
- [x] implement static location in order to match via static URL instead of window.history.pathname
```js
import { createBrowserHistory } from "history";

<Router
    staticLocation="/base/en/about"      // <-- new props used by node server
    langService={langService}
    routes={routesList}
    base={base}
>
  <App />
</Router>
```
- [x] manage active link class on server
- [x] add forwardRef wrapper function on `<Link />` component
- [x] add staticLocation documentation

## Breaking change

- Router props history didn't have default props anymore. We need to add `history={createBrowserHistory()}` explicitly as props.

```js
import { createBrowserHistory } from "history";

<Router
    history={createBrowserHistory()}
    langService={langService}
    routes={routesList}
    base={base}
>
  <App />
</Router>
```