### PR TITLE
Fix/matcher sub router

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,6 @@ const router = useRouter();
 // previousRoute and currentRoute
 type TRoute = {
   path: string | { [x: string]: string };
-  langPath: { [x: string]: string } | null;
   component: React.ComponentType<any>;
   base: string;
   name: string;
@@ -516,6 +515,7 @@ type TRoute = {
   getStaticProps: (props: TRouteProps) => Promise<any>;
   _fullUrl: string; // full URL who not depend of current instance
   _fullPath: string; // full Path /base/:lang/foo/second-foo
+  _langPath: { [x: string]: string } | null;
   _context: TRoute;
 };
 ```

--- a/README.md
+++ b/README.md
@@ -504,13 +504,19 @@ const router = useRouter();
 ```ts
 // previousRoute and currentRoute
 type TRoute = {
-  path: string;
+  path: string | { [x: string]: string };
+  langPath: { [x: string]: string } | null;
   component: React.ComponentType<any>;
-  props?: { [x: string]: any };
-  parser?: Path;
-  children?: TRoute[];
-  matchUrl?: string;
-  fullUrl?: string;
+  base: string;
+  name: string;
+  parser: Match;
+  props: TRouteProps;
+  children: TRoute[];
+  url: string;
+  getStaticProps: (props: TRouteProps) => Promise<any>;
+  _fullUrl: string; // full URL who not depend of current instance
+  _fullPath: string; // full Path /base/:lang/foo/second-foo
+  _context: TRoute;
 };
 ```
 

--- a/examples/example-client/src/pages/AboutPage.tsx
+++ b/examples/example-client/src/pages/AboutPage.tsx
@@ -10,8 +10,7 @@ import {
   useStack,
 } from "@cher-ami/router";
 import { transitionsHelper } from "../helper/transitionsHelper";
-import {routesList} from "../routes"
-
+import { routesList } from "../routes";
 
 const componentName: string = "AboutPage";
 
@@ -29,12 +28,6 @@ const AboutPage = forwardRef((props, handleRef: ForwardedRef<any>) => {
   // prepare routes & base for subRouter
   const router = useRouter();
   const path = getPathByRouteName(routesList, "AboutPage");
-
-  console.log(
-    "getSubRouterRoutes(path, router.routes)",
-    "/base/about",
-    getSubRouterRoutes(path, router.routes)
-  );
 
   return (
     <div className={componentName} ref={rootRef}>

--- a/examples/example-client/src/pages/BarPage.tsx
+++ b/examples/example-client/src/pages/BarPage.tsx
@@ -3,7 +3,6 @@ import {
   getPathByRouteName,
   getSubRouterBase,
   getSubRouterRoutes,
-  openRoute,
   useStack,
   Link,
   Router,
@@ -30,17 +29,19 @@ export const BarPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) 
 
   const router = useRouter();
   const path = getPathByRouteName(routesList, "BarPage");
+  console.log("getPathByRouteName", path);
+
+  console.log(
+    "getSubRouterRoutes(path, router.routes)",
+    getSubRouterRoutes(path, router.routes)
+  );
 
   return (
     <div className={componentName} ref={rootRef}>
       {componentName}
-      <br />
-      <Link to={{ name: "OurPage" }}>Our</Link>
-      <br />
-      <button onClick={() => openRoute({ name: "OurPage" })}>OurPage</button>
       <Router
         id={3}
-        base={getSubRouterBase(path, router.base, false)}
+        base={getSubRouterBase(path, router.base, true)}
         routes={getSubRouterRoutes(path, router.routes)}
       >
         <div className={componentName}>
@@ -50,7 +51,7 @@ export const BarPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>) 
                 <Link to={{ name: "YoloPage" }}>Yolo</Link>
               </li>
               <li>
-                <Link to={{ name: "HelloPage" }}>Hello (has sub router)</Link>
+                <Link to={{ name: "HelloPage" }}>Hello</Link>
               </li>
             </ul>
           </nav>

--- a/examples/example-client/src/pages/HelloPage.tsx
+++ b/examples/example-client/src/pages/HelloPage.tsx
@@ -1,9 +1,6 @@
 import React, { ForwardedRef, forwardRef, useRef } from "react";
-import { useRouter } from "@cher-ami/router";
 import { useStack } from "@cher-ami/router";
-import { getPathByRouteName } from "@cher-ami/router";
 import { transitionsHelper } from "../helper/transitionsHelper";
-import { routesList } from "../routes";
 
 const componentName: string = "HelloPage";
 
@@ -20,8 +17,6 @@ export const HelloPage = forwardRef((props: IProps, handleRef: ForwardedRef<any>
     playOut: () => transitionsHelper(rootRef.current, false),
   });
 
-  const router = useRouter();
-  const path = getPathByRouteName(routesList, "HelloPage");
   return (
     <div className={componentName} ref={rootRef}>
       {componentName}

--- a/examples/example-client/src/routes.ts
+++ b/examples/example-client/src/routes.ts
@@ -35,7 +35,7 @@ export const routesList: TRoute[] = [
           {
             path: "/hello",
             component: HelloPage,
-          }
+          },
         ],
       },
     ],
@@ -52,10 +52,10 @@ export const routesList: TRoute[] = [
       {
         path: "/our",
         component: OurPage,
-      }
+      },
     ],
   },
-   {
+  {
     // path: "/blog/:id",
     path: { en: "/blog/:id", fr: "/blog-fr/:id", de: "/blog-de/:id" },
     component: ArticlePage,

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -17,6 +17,7 @@ export type TRouteProps = {
 
 export type TRoute = Partial<{
   path: string | { [x: string]: string };
+  langPath: { [x: string]: string } | null;
   component: React.ComponentType<any>;
   base: string;
   name: string;
@@ -24,11 +25,9 @@ export type TRoute = Partial<{
   props: TRouteProps;
   children: TRoute[];
   url: string;
-  fullUrl: string; // full URL who not depend of current instance
-  fullPath: string; // full Path /base/:lang/foo/second-foo
-  langPath: { [x: string]: string } | null;
-  action?: () => any;
-  getStaticProps?: (props: TRouteProps) => Promise<any>;
+  getStaticProps: (props: TRouteProps) => Promise<any>;
+  _fullUrl: string; // full URL who not depend of current instance
+  _fullPath: string; // full Path /base/:lang/foo/second-foo
   _context: TRoute;
 }>;
 
@@ -269,7 +268,7 @@ function Router(props: {
       const cache = staticPropsCache();
 
       // check if new route data as been store in cache
-      const dataFromCache = cache.get(newRoute.fullUrl);
+      const dataFromCache = cache.get(newRoute._fullUrl);
 
       // first route visited (server & client)
       const isFirstRouteVisited = newRoute.name === props.initialStaticProps.name;
@@ -280,7 +279,7 @@ function Router(props: {
           Object.assign(newRoute.props, props.initialStaticProps?.props ?? {});
         }
         if (!dataFromCache) {
-          cache.set(newRoute.fullUrl, props.initialStaticProps?.props ?? {});
+          cache.set(newRoute._fullUrl, props.initialStaticProps?.props ?? {});
         }
       }
       // if NOT first route (client)
@@ -294,7 +293,7 @@ function Router(props: {
           try {
             const requestStaticProps = await newRoute.getStaticProps(newRoute.props);
             Object.assign(newRoute.props, requestStaticProps);
-            cache.set(newRoute.fullUrl, requestStaticProps);
+            cache.set(newRoute._fullUrl, requestStaticProps);
           } catch (e) {
             console.error("requestStaticProps failed");
           }

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -17,7 +17,6 @@ export type TRouteProps = {
 
 export type TRoute = Partial<{
   path: string | { [x: string]: string };
-  langPath: { [x: string]: string } | null;
   component: React.ComponentType<any>;
   base: string;
   name: string;
@@ -28,6 +27,7 @@ export type TRoute = Partial<{
   getStaticProps: (props: TRouteProps) => Promise<any>;
   _fullUrl: string; // full URL who not depend of current instance
   _fullPath: string; // full Path /base/:lang/foo/second-foo
+  _langPath: { [x: string]: string } | null;
   _context: TRoute;
 }>;
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -23,13 +23,13 @@ export type TRoute = Partial<{
   parser: Match;
   props: TRouteProps;
   children: TRoute[];
-  parent: TRoute
   url: string;
   fullUrl: string; // full URL who not depend of current instance
   fullPath: string; // full Path /base/:lang/foo/second-foo
   langPath: { [x: string]: string } | null;
   action?: () => any;
   getStaticProps?: (props: TRouteProps) => Promise<any>;
+  _context: TRoute;
 }>;
 
 export interface IRouterContextStackStates {
@@ -251,8 +251,11 @@ function Router(props: {
       return;
     }
 
-    const currentRouteUrl = currentRouteRef.current?.url;
-    if (currentRouteUrl != null && currentRouteUrl === matchingRoute?.url) {
+    const currentRouteUrl =
+      currentRouteRef.current?._context?.url ?? currentRouteRef.current?.url;
+    const matchingRouteUrl = matchingRoute?._context?.url ?? matchingRoute?.url;
+
+    if (currentRouteUrl === matchingRouteUrl) {
       log(props.id, "this is the same route 'url', return.");
       return;
     }

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -23,6 +23,7 @@ export type TRoute = Partial<{
   parser: Match;
   props: TRouteProps;
   children: TRoute[];
+  parent: TRoute
   url: string;
   fullUrl: string; // full URL who not depend of current instance
   fullPath: string; // full Path /base/:lang/foo/second-foo

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -74,8 +74,8 @@ function Stack(props: IProps): JSX.Element {
 
 
   const [PrevRoute, CurrRoute] = [
-    previousRoute?.parent ?? previousRoute,
-    currentRoute?.parent ?? currentRoute,
+    previousRoute?._context ?? previousRoute,
+    currentRoute?._context ?? currentRoute,
   ];
 
   return (

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -83,14 +83,14 @@ function Stack(props: IProps): JSX.Element {
       {previousPageIsMount && PrevRoute?.component && (
         <PrevRoute.component
           ref={prevRef}
-          key={`${PrevRoute.fullUrl || ""}_${routeIndex - 1}`}
+          key={`${PrevRoute._fullUrl || ""}_${routeIndex - 1}`}
           {...(PrevRoute.props || {})}
         />
       )}
       {CurrRoute?.component && (
         <CurrRoute.component
           ref={currentRef}
-          key={`${CurrRoute?.fullUrl || ""}_${routeIndex}`}
+          key={`${CurrRoute?._fullUrl || ""}_${routeIndex}`}
           {...(CurrRoute.props || {})}
         />
       )}

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -72,20 +72,26 @@ function Stack(props: IProps): JSX.Element {
     });
   }, [routeIndex]);
 
+
+  const [PrevRoute, CurrRoute] = [
+    previousRoute?.parent ?? previousRoute,
+    currentRoute?.parent ?? currentRoute,
+  ];
+
   return (
     <div className={["Stack", props.className].filter((e) => e).join(" ")}>
-      {previousPageIsMount && previousRoute?.component && (
-        <previousRoute.component
+      {previousPageIsMount && PrevRoute?.component && (
+        <PrevRoute.component
           ref={prevRef}
-          key={`${previousRoute?.fullUrl || ""}_${routeIndex - 1}`}
-          {...(previousRoute.props || {})}
+          key={`${PrevRoute.fullUrl || ""}_${routeIndex - 1}`}
+          {...(PrevRoute.props || {})}
         />
       )}
-      {currentRoute?.component && (
-        <currentRoute.component
+      {CurrRoute?.component && (
+        <CurrRoute.component
           ref={currentRef}
-          key={`${currentRoute?.fullUrl || ""}_${routeIndex}`}
-          {...(currentRoute.props || {})}
+          key={`${CurrRoute?.fullUrl || ""}_${routeIndex}`}
+          {...(CurrRoute.props || {})}
         />
       )}
     </div>

--- a/src/core/LangService.test.tsx
+++ b/src/core/LangService.test.tsx
@@ -94,14 +94,12 @@ it("should not redirect to default lang if showDefaultLangInUrl is set to false"
 const routesListLang: TRoute[] = [
   {
     path: "/",
-    langPath: null,
   },
   {
     path: "/hello",
-    langPath: null,
     children: [
-      { path: { en: "/zoo-en", fr: "/zoo-fr", de: "zoo-de" }, langPath: null },
-      { path: "/:id", langPath: null },
+      { path: { en: "/zoo-en", fr: "/zoo-fr", de: "zoo-de" }, _langPath: null },
+      { path: "/:id", },
     ],
   },
 ];
@@ -109,17 +107,17 @@ const routesListLang: TRoute[] = [
 const patchedRoutesListLang: TRoute[] = [
   {
     path: "/:lang",
-    langPath: { en: "/:lang", fr: "/:lang", de: "/:lang" },
+    _langPath: { en: "/:lang", fr: "/:lang", de: "/:lang" },
   },
   {
     path: "/:lang/hello",
-    langPath: { en: "/:lang/hello", fr: "/:lang/hello", de: "/:lang/hello" },
+    _langPath: { en: "/:lang/hello", fr: "/:lang/hello", de: "/:lang/hello" },
     children: [
       {
         path: "/zoo-en",
-        langPath: { en: "/zoo-en", fr: "/zoo-fr", de: "zoo-de" },
+        _langPath: { en: "/zoo-en", fr: "/zoo-fr", de: "zoo-de" },
       },
-      { path: "/:id", langPath: { en: "/:id", fr: "/:id", de: "/:id" } },
+      { path: "/:id", _langPath: { en: "/:id", fr: "/:id", de: "/:id" } },
     ],
   },
 ];

--- a/src/core/LangService.ts
+++ b/src/core/LangService.ts
@@ -236,7 +236,7 @@ class LangService<TLang = any> {
     routes: TRoute[],
     showLangInUrl = this.showLangInUrl()
   ): TRoute[] {
-    if (routes?.some((el) => !!el.langPath)) {
+    if (routes?.some((el) => !!el._langPath)) {
       log(
         "Routes have already been formatted by 'addLangParamToRoutes()', return routes."
       );
@@ -265,7 +265,7 @@ class LangService<TLang = any> {
      *  return:
      *    {
      *      path: "/:lang/home",
-     *      langPath: { en: "/:lang/home", fr: "/:lang/accueil" },
+     *      _langPath: { en: "/:lang/home", fr: "/:lang/accueil" },
      *    }
      *
      */
@@ -294,7 +294,7 @@ class LangService<TLang = any> {
         return {
           ...route,
           path: patchLangParam(path, showLang),
-          langPath: Object.entries(langPath).length !== 0 ? langPath : null,
+          _langPath: Object.entries(langPath).length !== 0 ? langPath : null,
           ...(hasChildren ? { children: patchRoutes(route.children, true) } : {}),
         };
       });

--- a/src/core/LangService.ts
+++ b/src/core/LangService.ts
@@ -81,7 +81,7 @@ class LangService<TLang = any> {
 
   /**
    * Set new lang to URL
-   * Use fullUrl of last router instance (and not path), to manage lang as needed
+   * Use _fullUrl of last router instance (and not path), to manage lang as needed
    *
    *    ex:
    *      -> /base/lang/path     (with lang)

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -220,8 +220,6 @@ describe("matcher", () => {
         pBase: "/",
       });
 
-      console.log("getRoute", getRoute);
-
       expect(getRoute.fullPath).toBe(`/about/route2/:testParam?/foo4`);
       expect(getRoute.path).toBe("/foo4");
       expect(getRoute.fullUrl).toBe(`/about/route2/super-param/foo4`);

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -158,6 +158,7 @@ describe("matcher", () => {
     },
     {
       path: "/about",
+      name: "AboutPage",
       children: [
         {
           path: "/route2",
@@ -169,6 +170,7 @@ describe("matcher", () => {
                 {
                   path: "/foo4",
                   props: { color: "red" },
+                  name: "Foo4Page",
                 },
               ],
             },
@@ -213,17 +215,23 @@ describe("matcher", () => {
 
     it("should get right route from URL with subRoute", () => {
       const getRoute = getRouteFromUrl({
-        pUrl: "/about/route2/super/foo4",
+        pUrl: "/about/route2/super-param/foo4",
         pRoutes: routesList,
         pBase: "/",
       });
 
-      expect(getRoute.fullUrl).toBe(`/about/route2/super/foo4`);
+      console.log("getRoute", getRoute);
+
       expect(getRoute.fullPath).toBe(`/about/route2/:testParam?/foo4`);
-      // this is the component we need to render at this level
-      expect(getRoute.path).toBe("/about");
-      expect(getRoute.url).toBe("/about");
-      expect(getRoute.props).toEqual({ params: { testParam: "super" } });
+      expect(getRoute.path).toBe("/foo4");
+      expect(getRoute.fullUrl).toBe(`/about/route2/super-param/foo4`);
+      expect(getRoute.url).toBe("/foo4");
+      expect(getRoute.base).toBe("/about/route2/:testParam?");
+      expect(getRoute.name).toBe("Foo4Page");
+      expect(getRoute.props).toEqual({
+        color: "red",
+        params: { testParam: "super-param" },
+      });
     });
 
     it("should not get route from bad URL and return undefined", () => {

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -1,7 +1,7 @@
 import {
   compileUrl,
   getPathByRouteName,
-  getFullPathByPath,
+  get_fullPathByPath,
   getUrlByRouteName,
   requestStaticPropsFromRoute,
   getRouteFromUrl,
@@ -192,8 +192,8 @@ describe("matcher", () => {
         pBase: base,
       });
 
-      expect(getRoute.fullUrl).toBe(`${base}/bar/my-id`);
-      expect(getRoute.fullPath).toBe(`${base}/bar/:id`);
+      expect(getRoute._fullUrl).toBe(`${base}/bar/my-id`);
+      expect(getRoute._fullPath).toBe(`${base}/bar/:id`);
       expect(getRoute.path).toBe("/bar/:id");
       expect(getRoute.url).toBe("/bar/my-id");
       expect(getRoute.name).toBe(`BarPage`);
@@ -202,7 +202,7 @@ describe("matcher", () => {
       // example-client 2
       // prettier-ignore
       const getRoute3 = getRouteFromUrl({ pUrl: "/hello-2", pRoutes: routesList, pBase: "/" });
-      expect(getRoute3.fullPath).toBe(`/hello-2`);
+      expect(getRoute3._fullPath).toBe(`/hello-2`);
 
       // example-client 3
       const getRoute2 = getRouteFromUrl({
@@ -220,9 +220,9 @@ describe("matcher", () => {
         pBase: "/",
       });
 
-      expect(getRoute.fullPath).toBe(`/about/route2/:testParam?/foo4`);
+      expect(getRoute._fullPath).toBe(`/about/route2/:testParam?/foo4`);
       expect(getRoute.path).toBe("/foo4");
-      expect(getRoute.fullUrl).toBe(`/about/route2/super-param/foo4`);
+      expect(getRoute._fullUrl).toBe(`/about/route2/super-param/foo4`);
       expect(getRoute.url).toBe("/foo4");
       expect(getRoute.base).toBe("/about/route2/:testParam?");
       expect(getRoute.name).toBe("Foo4Page");
@@ -291,14 +291,14 @@ describe("compileUrl", () => {
   });
 });
 
-describe("getFullPathByPath", () => {
+describe("get_fullPathByPath", () => {
   it("should return the full path", () => {
-    expect(getFullPathByPath(routesList, "/foo", "fooPage")).toBe("/hello/foo");
-    expect(getFullPathByPath(routesList, "/yes", "yesPage")).toBe("/hello/foo/bla/yes");
-    expect(getFullPathByPath(routesList, "/", "firstLevelRoute-2")).toBe(
+    expect(get_fullPathByPath(routesList, "/foo", "fooPage")).toBe("/hello/foo");
+    expect(get_fullPathByPath(routesList, "/yes", "yesPage")).toBe("/hello/foo/bla/yes");
+    expect(get_fullPathByPath(routesList, "/", "firstLevelRoute-2")).toBe(
       "/hello/foo/bla/"
     );
-    expect(getFullPathByPath(routesList, "/no", "noPage")).toBe("/hello/foo/bla/no");
+    expect(get_fullPathByPath(routesList, "/no", "noPage")).toBe("/hello/foo/bla/no");
   });
 });
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -286,7 +286,7 @@ export function getRouteFromUrl({
 
         const routeObj = {
           ...formatRouteObj(currentRoute),
-          _context: pParent && formatRouteObj(pParent),
+          _context: pParent && formatRouteObj(pParent || currentRoute),
         };
 
         log(id, "getRouteFromUrl: MATCH routeObj", routeObj);

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -285,7 +285,7 @@ export function getRouteFromUrl({
 
         const routeObj = {
           ...formatRouteObj(currentRoute),
-          _context: pParent && formatRouteObj(pParent || currentRoute),
+          _context: formatRouteObj(pParent || currentRoute),
         };
 
         log(id, "getRouteFromUrl: MATCH routeObj", routeObj);

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -266,9 +266,7 @@ export function getRouteFromUrl({
         const params = pMatcher?.params || matcher?.params;
 
         const formatRouteObj = (route) => ({
-          fullPath: currentRoutePath,
           path: route?.path,
-          fullUrl: pUrl,
           url: compile(route.path as string)(params),
           base: pBase,
           component: route?.component,
@@ -276,12 +274,13 @@ export function getRouteFromUrl({
           parser: pMatcher || matcher,
           langPath: route?.langPath,
           name: route?.name || route?.component?.displayName,
-          action: route?.action,
           getStaticProps: route?.getStaticProps,
           props: {
             params,
             ...(route?.props || {}),
           },
+          _fullPath: currentRoutePath,
+          _fullUrl: pUrl,
         });
 
         const routeObj = {
@@ -434,7 +433,7 @@ export function compileUrl(path: string, params?: TParams): string {
  *  With the second URL part "/foo", this function will returns "/bar/foo"
  * @returns string
  */
-export function getFullPathByPath(
+export function get_fullPathByPath(
   routes: TRoute[],
   path: string | { [x: string]: string },
   routeName: string,
@@ -459,7 +458,7 @@ export function getFullPathByPath(
     // if not matching but as children, return it
     else if (route?.children?.length > 0) {
       // no match, recall recursively on children
-      const matchChildrenPath = getFullPathByPath(
+      const matchChildrenPath = get_fullPathByPath(
         route.children,
         path,
         routeName,
@@ -471,7 +470,7 @@ export function getFullPathByPath(
         // keep path in local array
         localPath.push(langPath || routePath);
         // Return the function after localPath push
-        return getFullPathByPath(
+        return get_fullPathByPath(
           route.children,
           path,
           routeName,
@@ -506,15 +505,15 @@ export function getUrlByRouteName(pRoutes: TRoute[], pParams: TOpenRouteParams):
             : route.path;
 
         // get full path
-        const fullPath = getFullPathByPath(
+        const _fullPath = get_fullPathByPath(
           pRoutes,
           path,
           route.name,
           pParams?.params?.lang
         );
         // build URL
-        // console.log("fullPath", fullPath, params);
-        return compileUrl(fullPath, params.params);
+        // console.log("_fullPath", _fullPath, params);
+        return compileUrl(_fullPath, params.params);
       }
 
       // if route has children

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -361,7 +361,7 @@ export function patchMissingRootRoute(routes: TRoute[] = Routers.routes): TRoute
     routes.unshift({
       path: "/",
       component: null,
-      name: `1stLevelRoute-${Math.random()}`,
+      name: `auto-generate-slash-route-${Math.random()}`,
     });
   }
   return routes;

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -226,6 +226,7 @@ type TGetRouteFromUrl = {
   pBase?: string;
   pCurrentRoute?: TRoute;
   pMatcher?: any;
+  pParent?: TRoute;
   id?: number | string;
 };
 
@@ -238,6 +239,7 @@ export function getRouteFromUrl({
   pRoutes,
   pBase,
   pMatcher,
+  pParent,
   id,
 }: TGetRouteFromUrl): TRoute {
   if (!pRoutes || pRoutes?.length === 0) return;
@@ -246,7 +248,14 @@ export function getRouteFromUrl({
   // this route object is obj to return even if URL match
   let firstLevelCurrentRoute = undefined;
 
-  function next({ pUrl, pRoutes, pBase, pMatcher, id }: TGetRouteFromUrl): TRoute {
+  function next({
+    pUrl,
+    pRoutes,
+    pBase,
+    pMatcher,
+    pParent,
+    id,
+  }: TGetRouteFromUrl): TRoute {
     // test each routes
     for (let currentRoute of pRoutes) {
       // create parser & matcher
@@ -268,6 +277,7 @@ export function getRouteFromUrl({
           fullUrl: pUrl,
           url: compile(route.path)(params),
           base: pBase,
+          parent: pParent,
           component: route?.component,
           children: route?.children,
           parser: pMatcher || matcher,
@@ -288,7 +298,7 @@ export function getRouteFromUrl({
       // if not match
       else if (currentRoute?.children) {
         if (!firstLevelCurrentRoute) {
-          firstLevelCurrentRoute = currentRoute;
+          // firstLevelCurrentRoute = currentRoute;
         }
 
         // else, call recursively this same method with new params
@@ -296,6 +306,7 @@ export function getRouteFromUrl({
           pUrl,
           id,
           pRoutes: currentRoute?.children,
+          pParent: currentRoute,
           pBase: currentRoutePath, // parent base
           pCurrentRoute: firstLevelCurrentRoute || currentRoute,
           pMatcher: matcher,

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -272,7 +272,6 @@ export function getRouteFromUrl({
           component: route?.component,
           children: route?.children,
           parser: pMatcher || matcher,
-          langPath: route?.langPath,
           name: route?.name || route?.component?.displayName,
           getStaticProps: route?.getStaticProps,
           props: {
@@ -281,6 +280,7 @@ export function getRouteFromUrl({
           },
           _fullPath: currentRoutePath,
           _fullUrl: pUrl,
+          _langPath: route?._langPath,
         });
 
         const routeObj = {
@@ -443,7 +443,7 @@ export function get_fullPathByPath(
   let localPath: string[] = [basePath];
 
   for (let route of routes) {
-    const langPath = route.langPath?.[lang];
+    const langPath = route._langPath?.[lang];
     const routePath = route.path as string;
 
     const pathMatch =


### PR DESCRIPTION
routes list:

```ts
{
    path: "/about",
    component: AboutPage,
    children: [
      {
        path: "/foo",
        component: FooPage,
      },
      {
        path: "/bar",
        component: BarPage,
      },
    ],
},
```

In this example, we have a main router (1) and a subRouter (2) instance.

When we were in `AboutPage`, and the URL was `/about/foo`, `currentRoute` was returned the route object needed by `Stack` component and not really the current route from URL. 

before, URL is "/about/foo" & log `curentRoute` in `AboutPage`:

```ts
// currentRoute obj
{
  name: "AboutPage,
  path: "/about"
  ...
}
```

more logical after, URL is "/about/foo" & log `curentRoute` in `AboutPage`:

```ts
// currentRoute obj
{
  name: "FooPage,
  path: "/foo"
  _context: {
     name: "AboutPage",
     path: "/about"
  }
  ...
}
```

The main issue is the mix between the parse URL logic (witch need to return the appropriate route object from URL) and the stack render.

`currentRoute` object is the result of `getRouteFromUrl( url )`. If `url` param is `/about/foo`, we expect to receive the object corresponding to this URL. BUT the stack render need the current "context", first router instance will not return `FooPage` but `AboutPage`. So The stack have to check the `_context` key object if he is has a subrouter.

---

- [x] reorganize route Object :
(add "_" on internal properties)
```ts
type TRoute = {
  path: string | { [x: string]: string };
  component: React.ComponentType<any>;
  base: string;
  name: string;
  parser: Match;
  props: TRouteProps;
  children: TRoute[];
  url: string;
  getStaticProps: (props: TRouteProps) => Promise<any>;
  _fullUrl: string; // full URL who not depend of current instance
  _fullPath: string; // full Path /base/:lang/foo/second-foo
  _langPath: { [x: string]: string } | null;
  _context: TRoute;
};
```


