### PR TITLE
Fix/ context route format

### DIFF
--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -111,7 +111,10 @@ describe("matcher", () => {
       expect(getRoute.path).toBe("/bar/:id");
       expect(getRoute.url).toBe("/bar/my-id");
       expect(getRoute.name).toBe(`BarPage`);
-      expect(getRoute.props).toEqual({ params: { id: "my-id" }, color: "blue" });
+      const routeProps = { params: { id: "my-id" }, color: "blue" };
+      expect(getRoute.props).toEqual(routeProps);
+      // no parent route, so context object need to return same route information
+      expect(getRoute._context.props).toEqual(routeProps);
 
       getRoute = getRouteFromUrl({
         pUrl: "/hello-2",

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -265,27 +265,31 @@ export function getRouteFromUrl({
       if (matcher) {
         const params = pMatcher?.params || matcher?.params;
 
-        const formatRouteObj = (route) => ({
-          path: route?.path,
-          url: compile(route.path as string)(params),
-          base: pBase,
-          component: route?.component,
-          children: route?.children,
-          parser: pMatcher || matcher,
-          name: route?.name || route?.component?.displayName,
-          getStaticProps: route?.getStaticProps,
-          props: {
-            params,
-            ...(route?.props || {}),
-          },
-          _fullPath: currentRoutePath,
-          _fullUrl: pUrl,
-          _langPath: route?._langPath,
-        });
+        const formatRouteObj = (route) => {
+          if (!route) return;
+          return {
+            path: route?.path,
+            url: compile(route.path as string)(params),
+            base: pBase,
+            component: route?.component,
+            children: route?.children,
+            parser: pMatcher || matcher,
+            name: route?.name || route?.component?.displayName,
+            getStaticProps: route?.getStaticProps,
+            props: {
+              params,
+              ...(route?.props || {}),
+            },
+            _fullPath: currentRoutePath,
+            _fullUrl: pUrl,
+            _langPath: route?._langPath,
+          };
+        };
 
+        const formattedCurrentRoute = formatRouteObj(currentRoute);
         const routeObj = {
-          ...formatRouteObj(currentRoute),
-          _context: formatRouteObj(pParent || currentRoute),
+          ...formattedCurrentRoute,
+          _context: pParent ? formatRouteObj(pParent) : formattedCurrentRoute,
         };
 
         log(id, "getRouteFromUrl: MATCH routeObj", routeObj);
@@ -330,7 +334,7 @@ export function getNotFoundRoute(routes: TRoute[]): TRoute {
 
 /**
  * Add missing route with "/" on children routes if doesn't exist.
- * 
+ *
  * this is not a recursive function, "/" route will be insert only on first level.
  *
  * [


### PR DESCRIPTION
_context obj needs to return formatted current route if pParent doesn't exist. 