### PR TITLE
Create redirect to browserLang method

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,17 +829,25 @@ component only.
 langService.setLang({ key: "de" });
 ```
 
-#### redirect(forcePageReload = true) `void`
+#### redirectToDefaultLang(forcePageReload = true) `void`
 
 If URL is `/`, `showDefaultLangInUrl` is set to `true` and default lang is 'en',
-it will redirect to `/en`. This method can be called in nested router component
-only.
+it will redirect to `/en`.
 
 - `forcePageReload`: choose if we reload the full application or using the
   internal router stack to change the language
 
-```jsx
-langService.redirect();
+```js
+langService.redirectToDefaultLang();
+```
+
+#### redirectToBrowserLang(forcePageReload = true) `void`
+
+Same than `redirectToDefaultLang` method but redirect to the user `navigator.language`.
+If the browser language doesn't exist in Languages array, we redirect to the default lang. 
+
+```js
+langService.redirectToBrowserLang();
 ```
 
 ### <a name="TranslatePath"></a>Translate Path

--- a/examples/example-ssr/src/components/App.tsx
+++ b/examples/example-ssr/src/components/App.tsx
@@ -1,10 +1,17 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Link, Stack, useLang } from "@cher-ami/router";
 import languages from "../languages";
 import { EPages } from "../routes";
+import { useRouter } from "@cher-ami/router";
 
 export function App() {
+  const { langService } = useRouter();
   const [lang, setLang] = useLang();
+
+  useEffect(() => {
+    console.log("langService", langService);
+    langService.redirectToDefaultLang()
+  }, []);
 
   const crossedTransitions = ({
     previousPage,

--- a/examples/example-ssr/src/index-server.tsx
+++ b/examples/example-ssr/src/index-server.tsx
@@ -26,7 +26,7 @@ export async function render(url: string) {
     const users = await res.json();
     return { users };
   };
-  let globalData = await requestGlobalData();
+  const globalData = await requestGlobalData();
 
   // Template for server
   const renderToString = ReactDOMServer.renderToString(

--- a/examples/example-ssr/src/langServiceInstance.ts
+++ b/examples/example-ssr/src/langServiceInstance.ts
@@ -3,8 +3,9 @@ import { LangService } from "@cher-ami/router";
 
 export const langServiceInstance = (base = "/", url = window.location.pathname) =>
   new LangService({
-    showDefaultLangInUrl: false,
+    showDefaultLangInUrl: true,
     staticLocation: url,
     languages,
     base,
   });
+

--- a/examples/example-ssr/src/languages.ts
+++ b/examples/example-ssr/src/languages.ts
@@ -1,1 +1,1 @@
-export default [{ key: "fr" }, { key: "en" }]
+export default [{ key: "fr" }, { key: "en", default: true }]

--- a/src/core/LangService.test.tsx
+++ b/src/core/LangService.test.tsx
@@ -53,7 +53,7 @@ it("should redirect to default lang", () => {
   const langService = new LangService({ languages: locales, base: "/" });
   render(<App langService={langService} />);
   act(() => {
-    langService.redirect(true);
+    langService.redirectToDefaultLang(true);
   });
   const defaultLangKey = langService.defaultLang.key;
   expect(window.open).toHaveBeenCalledWith(`/${defaultLangKey}`, "_self");
@@ -63,7 +63,7 @@ it("should redirect to default lang with custom base", () => {
   const langService = new LangService({ languages: locales, base: "/" });
   render(<App base={"/foo-base"} langService={langService} />);
   act(() => {
-    langService.redirect(true);
+    langService.redirectToDefaultLang(true);
   });
   const defaultLangKey = langService.defaultLang.key;
   expect(window.open).toHaveBeenCalledWith(`/${defaultLangKey}`, "_self");
@@ -77,7 +77,7 @@ it("should not redirect to default lang if showDefaultLangInUrl is set to false"
   });
   render(<App langService={langService} />);
   act(() => {
-    langService.redirect(true);
+    langService.redirectToDefaultLang(true);
   });
   expect(window.open).toHaveBeenCalledTimes(0);
 });


### PR DESCRIPTION
fix #128 

- create `langService.redirectToBrowserLang()`
- rename `langService.redirect()` to `langService.redirectToDefaultLang()`