### PR TITLE
Expose currentLang in getStaticProps param

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,18 +360,18 @@ The client will got this response.
 
 To be able to request on server side (and on client side too), `getStaticProps` route property is available:
 
-```jsx
+```ts
    {
     path: "/article/:slug",
     component: ArticlePage,
     name: "Article",
-    getStaticProps: async (props) => {
+    getStaticProps: async (props, currentLang) => {
       // props contains route props and params (ex: slug: "article-1")
-      const res = await fetch(`https://api.com/posts/${props.params.slug}`);
+      const res = await fetch(`https://api.com/posts/${currentLang.key}/${props.params.slug}`);
       const api = await res.json();
       return { api };
-    },
-  },
+    }
+  }
 ```
 
 Then, get the response data populated in page component props:

--- a/examples/example-ssr/src/routes.ts
+++ b/examples/example-ssr/src/routes.ts
@@ -22,7 +22,7 @@ export const routes: TRoute[] = [
     path: "/",
     component: HomePage,
     name: EPages.HOME,
-    getStaticProps: async (props) => {
+    getStaticProps: async (props, currentLang) => {
       const res = await fetch("https://worldtimeapi.org/api/ip");
       const time = await res.json();
       return { time };

--- a/src/_fixtures/routeList.ts
+++ b/src/_fixtures/routeList.ts
@@ -21,10 +21,10 @@ export const routeList: TRoute[] = [
   {
     path: "/hello",
     name: "HelloPage",
-    getStaticProps: async (props) =>
+    getStaticProps: async (props, currentLang) =>
       new Promise((resolve) => {
         setTimeout(() => {
-          resolve({ fetchData: {} });
+          resolve({ data: {} });
         }, 100);
       }),
     children: [

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -5,7 +5,7 @@ import React, { useMemo } from "react";
 import { formatRoutes } from "../core/core";
 import { getNotFoundRoute, getRouteFromUrl } from "../core/core";
 import { Routers } from "../core/Routers";
-import LangService from "../core/LangService";
+import LangService, { TLanguage } from "../core/LangService";
 import { staticPropsCache } from "../core/staticPropsCache";
 import { isSSR } from "../core/helpers";
 
@@ -25,7 +25,7 @@ export type TRoute = Partial<{
   props: TRouteProps;
   children: TRoute[];
   url: string;
-  getStaticProps: (props: TRouteProps) => Promise<any>;
+  getStaticProps: (props: TRouteProps, currentLang: TLanguage) => Promise<any>;
   _fullUrl: string; // full URL who not depends on current instance
   _fullPath: string; // full Path /base/:lang/foo/second-foo
   _langPath: { [x: string]: string } | null;
@@ -277,7 +277,6 @@ function Router(props: {
     // first route visited (server & client)
     const isFirstRouteVisited = newRoute._fullUrl === props.initialStaticProps?.url;
     log(props.id, "is first route visited?", isFirstRouteVisited);
-
     // Server and client
     // check if is first route and initial static props exist
     // in this case, we assign this response to newPage props and cache it
@@ -306,7 +305,10 @@ function Router(props: {
           "Not first route & no initialStaticProps & no dataFromCache > request getStaticProps"
         );
         try {
-          const requestStaticProps = await newRoute.getStaticProps(newRoute.props);
+          const requestStaticProps = await newRoute.getStaticProps(
+            newRoute.props,
+            langService.currentLang
+          );
           Object.assign(newRoute.props, requestStaticProps);
           cache.set(newRoute._fullUrl, requestStaticProps);
         } catch (e) {

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -307,7 +307,7 @@ function Router(props: {
         try {
           const requestStaticProps = await newRoute.getStaticProps(
             newRoute.props,
-            langService.currentLang
+            langService?.currentLang
           );
           Object.assign(newRoute.props, requestStaticProps);
           cache.set(newRoute._fullUrl, requestStaticProps);

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -73,7 +73,9 @@ describe("public", () => {
       const homeChildren = getSubRouterRoutes("/", routeList);
       expect(homeChildren).toEqual(routeList.find((e) => e.name === "HomePage").children);
       const aboutChildren = getSubRouterRoutes("/about", routeList);
-      expect(aboutChildren).toEqual(routeList.find((e) => e.name === "AboutPage").children);
+      expect(aboutChildren).toEqual(
+        routeList.find((e) => e.name === "AboutPage").children
+      );
     });
   });
 
@@ -94,7 +96,7 @@ describe("public", () => {
         routes: routeList,
       });
       expect(ssrStaticProps).toEqual({
-        props: { fetchData: {} },
+        props: { data: {} },
         name: "HelloPage",
         url: "/hello",
       });

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -213,7 +213,10 @@ export async function requestStaticPropsFromRoute({
   // await promise from getStaticProps
   if (currentRoute?.getStaticProps) {
     try {
-      SSR_STATIC_PROPS.props = await currentRoute.getStaticProps(currentRoute.props, langService.currentLang);
+      SSR_STATIC_PROPS.props = await currentRoute.getStaticProps(
+        currentRoute.props,
+        langService?.currentLang
+      );
     } catch (e) {
       log("fetch getStatic Props data error");
     }

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -213,7 +213,7 @@ export async function requestStaticPropsFromRoute({
   // await promise from getStaticProps
   if (currentRoute?.getStaticProps) {
     try {
-      SSR_STATIC_PROPS.props = await currentRoute.getStaticProps(currentRoute.props);
+      SSR_STATIC_PROPS.props = await currentRoute.getStaticProps(currentRoute.props, langService.currentLang);
     } catch (e) {
       log("fetch getStatic Props data error");
     }


### PR DESCRIPTION
currentLang object is needed in getStaticProps route property to request URL by language

```ts
   {
    path: "/article/:slug",
    component: ArticlePage,
    name: "Article",
    getStaticProps: async (props, currentLang) => {
      // props contains route props and params (ex: slug: "article-1")
      const res = await fetch(`https://api.com/posts/${currentLang.key}/${props.params.slug}`);
      const api = await res.json();
      return { api };
    }
  }
```
