### PR TITLE
Copy queryParams & hash in props route

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -21,6 +21,8 @@ import { isSSR, removeLastCharFromString } from "../core/helpers"
 
 export type TRouteProps = {
   params?: TParams
+  queryParams?: TQueryParams
+  hash?: string
   [x: string]: any
 }
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -325,6 +325,8 @@ export function getRouteFromUrl({
             hash,
             props: {
               params,
+              queryParams,
+              hash,
               ...(route?.props || {}),
             },
             _fullPath: currentRoutePath,

--- a/src/tests/core.getRouteFromUrl.test.ts
+++ b/src/tests/core.getRouteFromUrl.test.ts
@@ -21,7 +21,12 @@ describe("getRouteFromUrl", () => {
     expect(getRoute.path).toBe("/bar/:id")
     expect(getRoute.url).toBe("/bar/my-id")
     expect(getRoute.name).toBe(`BarPage`)
-    const routeProps = { params: { id: "my-id" }, color: "blue" }
+    const routeProps = {
+      params: { id: "my-id" },
+      queryParams: {},
+      hash: null,
+      color: "blue",
+    }
     expect(getRoute.props).toEqual(routeProps)
     // no parent route, so context object need to return same route information
     expect(getRoute._context.props).toEqual(routeProps)
@@ -57,6 +62,8 @@ describe("getRouteFromUrl", () => {
     expect(getRoute.props).toEqual({
       color: "red",
       params: { testParam: "super-param" },
+      queryParams: {},
+      hash: null,
     })
   })
 


### PR DESCRIPTION
fix #151 


props route returns queryParams & hash
````ts
export type TRouteProps = {
  params?: TParams
  queryParams?: TQueryParams
  hash?: string
  [x: string]: any
}
````
