### PR TITLE
Fix queryparams hash history

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -3,7 +3,8 @@
   "sandboxes": [
     "/examples/example-client",
     "/examples/example-ssr",
-    "/examples/example-history-block"
+    "/examples/example-history-block",
+    "/examples/example-hash-history"
   ],
   "node": "18"
 }

--- a/examples/example-client/src/pages/AboutPage.tsx
+++ b/examples/example-client/src/pages/AboutPage.tsx
@@ -8,6 +8,7 @@ import {
   Router,
   useRouter,
   useStack,
+  useLang,
 } from "@cher-ami/router"
 import { transitionsHelper } from "../helper/transitionsHelper"
 import { routesList } from "../routes"
@@ -16,6 +17,8 @@ const componentName: string = "AboutPage"
 
 const AboutPage = forwardRef((props, handleRef: ForwardedRef<any>) => {
   const rootRef = useRef(null)
+  const [lang] = useLang()
+  const { currentRoute } = useRouter()
 
   useStack({
     componentName,
@@ -31,8 +34,15 @@ const AboutPage = forwardRef((props, handleRef: ForwardedRef<any>) => {
 
   return (
     <div className={componentName} ref={rootRef}>
-      {componentName}
-
+      <h1>
+        {componentName} - {lang.key}
+      </h1>
+      Query Params :
+      <ul>
+        <li>Foo : {currentRoute.queryParams?.foo} </li>
+        <li>Zoo : {currentRoute.queryParams?.zoo} </li>
+      </ul>
+      Children :
       <Router
         id={4}
         base={getSubRouterBase(path, router.base, true)}

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -281,8 +281,6 @@ function Router(
       return
     }
 
-    console.log("========> handleHistory", url)
-
     const matchingRoute = getRouteFromUrl({
       pUrl: url,
       pRoutes: routes,
@@ -309,17 +307,13 @@ function Router(
     const newRoute: TRoute = matchingRoute || notFoundRoute
     if (!newRoute) return
 
-    console.log("===================== newRoute _fullUrl", newRoute._fullUrl)
-
     // prepare cache for new route data staticProps
     const cache = staticPropsCache()
 
     // check if new route data as been store in cache
     // the matcher will match even if the URL ends with a slash
     const fullUrl = removeLastCharFromString(newRoute._fullUrl, "/")
-    console.log("===================== newRoute fullUrl", fullUrl)
     const [urlWithoutHash] = fullUrl.split("#")
-    console.log("===================== newRoute urlWithoutHash", urlWithoutHash)
 
     /**
      * Request static props and cache it
@@ -353,7 +347,6 @@ function Router(
         if (props.initialStaticProps) {
           log(props.id, "firstRoute > isClient > assign initialStaticProps to newRoute props & set cache");
           Object.assign(newRoute.props, props.initialStaticProps?.props ?? {});
-          console.log("===================== urlWithoutHash", urlWithoutHash)
           cache.set(urlWithoutHash, newRoute.props ?? {});
         }
         else if (newRoute.getStaticProps) {

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -281,6 +281,8 @@ function Router(
       return
     }
 
+    console.log("========> handleHistory", url)
+
     const matchingRoute = getRouteFromUrl({
       pUrl: url,
       pRoutes: routes,
@@ -307,13 +309,17 @@ function Router(
     const newRoute: TRoute = matchingRoute || notFoundRoute
     if (!newRoute) return
 
+    console.log("===================== newRoute _fullUrl", newRoute._fullUrl)
+
     // prepare cache for new route data staticProps
     const cache = staticPropsCache()
 
     // check if new route data as been store in cache
     // the matcher will match even if the URL ends with a slash
     const fullUrl = removeLastCharFromString(newRoute._fullUrl, "/")
+    console.log("===================== newRoute fullUrl", fullUrl)
     const [urlWithoutHash] = fullUrl.split("#")
+    console.log("===================== newRoute urlWithoutHash", urlWithoutHash)
 
     /**
      * Request static props and cache it
@@ -347,6 +353,7 @@ function Router(
         if (props.initialStaticProps) {
           log(props.id, "firstRoute > isClient > assign initialStaticProps to newRoute props & set cache");
           Object.assign(newRoute.props, props.initialStaticProps?.props ?? {});
+          console.log("===================== urlWithoutHash", urlWithoutHash)
           cache.set(urlWithoutHash, newRoute.props ?? {});
         }
         else if (newRoute.getStaticProps) {
@@ -398,9 +405,10 @@ function Router(
         return
         // client
       } else if (history) {
-        let url = window.location.pathname + window.location.search + window.location.hash
+        let url =
+          history.location.pathname + history.location.search + history.location.hash
         if (props.isHashHistory) {
-          url = history.location.pathname + window.location.search
+          url = history.location.pathname + history.location.search
         }
         handleHistory(url)
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -289,8 +289,6 @@ export function getRouteFromUrl({
     isHashHistory,
   )
 
-  console.log("======getRouteFromUrl  queryParams", queryParams)
-
   function next({
     pUrl,
     urlWithoutHashAndQuery,
@@ -404,7 +402,6 @@ export const extractQueryParamsAndHash = (
     return params
   }
 
-  console.log(" ===========> extractQueryParamsAndHash", url)
   let queryParams = {}
   let hash = null
   let newUrl = url

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -289,6 +289,8 @@ export function getRouteFromUrl({
     isHashHistory,
   )
 
+  console.log("======getRouteFromUrl  queryParams", queryParams)
+
   function next({
     pUrl,
     urlWithoutHashAndQuery,
@@ -402,6 +404,7 @@ export const extractQueryParamsAndHash = (
     return params
   }
 
+  console.log(" ===========> extractQueryParamsAndHash", url)
   let queryParams = {}
   let hash = null
   let newUrl = url

--- a/src/tests/core.getRouteFromUrl.test.ts
+++ b/src/tests/core.getRouteFromUrl.test.ts
@@ -114,27 +114,37 @@ describe("getRouteFromUrl", () => {
         children: [{ path: "/c" }, { path: "/d" }],
       },
     ]
-    // only params
+
+    // params
     let getRoute = getRouteFromUrl({
       pRoutes,
       pUrl: "/b?foo=bar&lang=en",
       isHashHistory: true,
     })
+
     expect(getRoute.queryParams).toEqual({ foo: "bar", lang: "en" })
     expect(getRoute._fullPath).toEqual("/b")
 
-    // only hash
-    getRoute = getRouteFromUrl({ pRoutes, pUrl: "/b/c", isHashHistory: true })
-    expect(getRoute._fullPath).toEqual("/b/c")
-    expect(getRoute.hash).toEqual(null)
-
-    // params and hash
-    getRoute = getRouteFromUrl({ pRoutes, pUrl: "/b/c?foo=bar", isHashHistory: true })
-    expect(getRoute.queryParams).toEqual({ foo: "bar" })
-
-    // not hash and params
+    // no params
     getRoute = getRouteFromUrl({ pRoutes, pUrl: "/a", isHashHistory: true })
     expect(getRoute.queryParams).toEqual({})
-    expect(getRoute.hash).toEqual(null)
+
+    // Subroutes
+    getRoute = getRouteFromUrl({
+      pRoutes,
+      pUrl: "/b/c",
+      isHashHistory: true,
+    })
+    expect(getRoute._fullPath).toEqual("/b/c")
+    expect(getRoute.queryParams).toEqual({})
+
+    // Subroutes with params
+    getRoute = getRouteFromUrl({
+      pRoutes,
+      pUrl: "/b/c?foo=bar&lang=en",
+      isHashHistory: true,
+    })
+    expect(getRoute._fullPath).toEqual("/b/c")
+    expect(getRoute.queryParams).toEqual({ foo: "bar", lang: "en" })
   })
 })


### PR DESCRIPTION
Fix queryParams hash history
- Use `history` instead of `window` on client side